### PR TITLE
Allow usage of IMDS instead of passing AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ ZeroFS can self-host! Here's a demo showing Rust's toolchain building ZeroFS whi
 - `AWS_DEFAULT_REGION`: AWS region (default: "us-east-1")
 - `AWS_ALLOW_HTTP`: Allow HTTP connections (default: "false")
 
+### Using IMDS
+
+If you have an IAM role attached to your instance, and you want to use it instead of passing the access key ID and secret key, just leave the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY variables empty.
+
 ## Mounting the Filesystem
 
 ### macOS
@@ -164,4 +168,3 @@ Key-Value Store:
 ## Future Enhancements
 
 - [ ] Snapshot capabilities using SlateDB's checkpoints
-

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -66,9 +66,20 @@ impl SlateDbFs {
         cache_config: CacheConfig,
         db_path: String,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut builder = AmazonS3Builder::from_env()
+        let mut builder = AmazonS3Builder::new()
             .with_bucket_name(&s3_config.bucket_name)
-            .with_region(&s3_config.region);
+            .with_region(&s3_config.region)
+            .with_allow_http(s3_config.allow_http)
+            .with_conditional_put(S3ConditionalPut::ETagMatch);
+
+        if !s3_config.access_key_id.is_empty() {
+            // Use IMDS for credentials if not provided
+            builder = builder.with_access_key_id(&s3_config.access_key_id);
+        }
+        if !s3_config.secret_access_key.is_empty() {
+            // Use provided credentials
+            builder = builder.with_secret_access_key(s3_config.secret_access_key);
+        }
 
         if !s3_config.endpoint.is_empty() {
             builder = builder.with_endpoint(&s3_config.endpoint);

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -66,13 +66,9 @@ impl SlateDbFs {
         cache_config: CacheConfig,
         db_path: String,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut builder = AmazonS3Builder::new()
+        let mut builder = AmazonS3Builder::from_env()
             .with_bucket_name(&s3_config.bucket_name)
-            .with_region(&s3_config.region)
-            .with_access_key_id(&s3_config.access_key_id)
-            .with_secret_access_key(&s3_config.secret_access_key)
-            .with_allow_http(s3_config.allow_http)
-            .with_conditional_put(S3ConditionalPut::ETagMatch);
+            .with_region(&s3_config.region);
 
         if !s3_config.endpoint.is_empty() {
             builder = builder.with_endpoint(&s3_config.endpoint);


### PR DESCRIPTION
Hello, I was browsing  Reddit yesterday, and by pure serendipity I found this, and it's exactly what we need.

However, I tried to use it in our EC2 instance with an IAM role attached. We prefer to not pass access keys if possible.

This PR implements IMDS support by conditionally passing the AWS key ID and secret key. If they are not passed, object_store automatically uses IMDS.

Thanks for the project, we are evaluating some options and so far this seems to be the best one.