### PR TITLE
Configurable IP and Port for the NFS socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Both modes share the same encrypted, compressed, cached storage backend.
 
 - `AWS_ENDPOINT_URL`: S3-compatible endpoint URL
 - `AWS_S3_BUCKET`: S3 bucket name (default: `"slatedb"`)
-- `AWS_ACCESS_KEY_ID`: AWS access key ID.
+- `AWS_ACCESS_KEY_ID`: AWS access key ID
 - `AWS_SECRET_ACCESS_KEY`: AWS secret access key
 - `AWS_DEFAULT_REGION`: AWS region (default: `"us-east-1"`)
 - `AWS_ALLOW_HTTP`: Allow HTTP connections (default: `"false"`)

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ Both modes share the same encrypted, compressed, cached storage backend.
 ### Optional Environment Variables
 
 - `AWS_ENDPOINT_URL`: S3-compatible endpoint URL
-- `AWS_S3_BUCKET`: S3 bucket name (default: "slatedb")
-- `AWS_ACCESS_KEY_ID`: AWS access key ID
+- `AWS_S3_BUCKET`: S3 bucket name (default: `"slatedb"`)
+- `AWS_ACCESS_KEY_ID`: AWS access key ID.
 - `AWS_SECRET_ACCESS_KEY`: AWS secret access key
-- `AWS_DEFAULT_REGION`: AWS region (default: "us-east-1")
-- `AWS_ALLOW_HTTP`: Allow HTTP connections (default: "false")
+- `AWS_DEFAULT_REGION`: AWS region (default: `"us-east-1"`)
+- `AWS_ALLOW_HTTP`: Allow HTTP connections (default: `"false"`)
+- `ZEROFS_NFS_HOST_IP`: IP address to bind the NFS TCP socket (default: `"127.0.0.1"`)
+- `ZEROFS_NFS_HOST_PORT`: Port to bind the NFS TCP socket (default: `2049`)
 - `ZEROFS_NBD_PORTS`: Comma-separated list of ports for NBD servers (optional)
-- `ZEROFS_NBD_DEVICE_SIZES_GB`: Comma-separated list of device sizes in GB (optional, must match NBD_PORTS count)
+- `ZEROFS_NBD_DEVICE_SIZES_GB`: Comma-separated list of device sizes in GB (optional, must match `ZEROFS_NBD_PORTS` count)
 - `ZEROFS_MEMORY_CACHE_SIZE_GB`: Size of ZeroFS in-memory cache in GB (optional, default: 0.25GB)
 
 ### Encryption

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Both modes share the same encrypted, compressed, cached storage backend.
 - `AWS_SECRET_ACCESS_KEY`: AWS secret access key
 - `AWS_DEFAULT_REGION`: AWS region (default: `"us-east-1"`)
 - `AWS_ALLOW_HTTP`: Allow HTTP connections (default: `"false"`)
-- `ZEROFS_NFS_HOST_IP`: IP address to bind the NFS TCP socket (default: `"127.0.0.1"`)
+- `ZEROFS_NFS_HOST`: Address (IP or hostname) to bind the NFS TCP socket (default: `"127.0.0.1"`)
 - `ZEROFS_NFS_HOST_PORT`: Port to bind the NFS TCP socket (default: `2049`)
+- `ZEROFS_NBD_HOST`: Address (IP or hostname) to bind the NBD TCP sockets (default: `"127.0.0.1"`)
 - `ZEROFS_NBD_PORTS`: Comma-separated list of ports for NBD servers (optional)
 - `ZEROFS_NBD_DEVICE_SIZES_GB`: Comma-separated list of device sizes in GB (optional, must match `ZEROFS_NBD_PORTS` count)
 - `ZEROFS_MEMORY_CACHE_SIZE_GB`: Size of ZeroFS in-memory cache in GB (optional, default: 0.25GB)

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-const DEFAULT_NFS_IP: &str = "127.0.0.1";
+const DEFAULT_NFS_HOST: &str = "127.0.0.1";
 const DEFAULT_NFS_PORT: u32 = 2049;
 
 // ANSI color codes
@@ -102,10 +102,13 @@ fn validate_environment() -> Result<(), Box<dyn std::error::Error>> {
             "  {BLUE}ZEROFS_NBD_DEVICE_SIZES_GB{RESET}     - Comma-separated NBD device sizes in GB"
         );
         eprintln!(
+            "  {BLUE}ZEROFS_NBD_HOST{RESET}                - NBD server bind address (default: 127.0.0.1)"
+        );
+        eprintln!(
             "  {BLUE}ZEROFS_NEW_PASSWORD{RESET}            - New password when changing encryption"
         );
         eprintln!(
-            "  {BLUE}ZEROFS_NFS_HOST_IP{RESET}             - NFS server bind IP (default: 127.0.0.1)"
+            "  {BLUE}ZEROFS_NFS_HOST{RESET}                - NFS server bind address (default: 127.0.0.1)"
         );
         eprintln!(
             "  {BLUE}ZEROFS_NFS_HOST_PORT{RESET}           - NFS server port (default: 2049)"
@@ -271,12 +274,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let nbd_ports = std::env::var("ZEROFS_NBD_PORTS").unwrap_or_else(|_| "".to_string());
     let nbd_device_sizes =
         std::env::var("ZEROFS_NBD_DEVICE_SIZES_GB").unwrap_or_else(|_| "".to_string());
+    let nbd_host = std::env::var("ZEROFS_NBD_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
 
     let fs_arc = Arc::new(fs);
 
     // Start NFS server
-    let zerofs_nfs_host_ip = std::env::var("ZEROFS_NFS_HOST_IP")
-        .unwrap_or_else(|_| DEFAULT_NFS_IP.to_string());
+    let zerofs_nfs_host =
+        std::env::var("ZEROFS_NFS_HOST").unwrap_or_else(|_| DEFAULT_NFS_HOST.to_string());
 
     let zerofs_nfs_host_port = std::env::var("ZEROFS_NFS_HOST_PORT")
         .map_or_else(|_| Ok(DEFAULT_NFS_PORT), |port| port.parse::<u32>())
@@ -284,7 +288,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let nfs_fs = Arc::clone(&fs_arc);
     let nfs_handle = tokio::spawn(async move {
-        match crate::nfs::start_nfs_server_with_config((*nfs_fs).clone(), &zerofs_nfs_host_ip, zerofs_nfs_host_port).await {
+        match crate::nfs::start_nfs_server_with_config(
+            (*nfs_fs).clone(),
+            &zerofs_nfs_host,
+            zerofs_nfs_host_port,
+        )
+        .await
+        {
             Ok(()) => Ok(()),
             Err(e) => Err(std::io::Error::other(e.to_string())),
         }
@@ -340,11 +350,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         for (&port, &size) in ports.iter().zip(sizes.iter()) {
-            let mut nbd_server = NBDServer::new(Arc::clone(&fs_arc), port);
+            let mut nbd_server = NBDServer::new(Arc::clone(&fs_arc), nbd_host.clone(), port);
             nbd_server.add_device(format!("device_{port}"), size);
 
             info!(
-                "Starting NBD server on port {} with device size {} GB",
+                "Starting NBD server on {}:{} with device size {} GB",
+                nbd_host,
                 port,
                 size as f64 / (1024.0 * 1024.0 * 1024.0)
             );

--- a/src/nbd.rs
+++ b/src/nbd.rs
@@ -66,14 +66,16 @@ pub struct NBDDevice {
 pub struct NBDServer {
     filesystem: Arc<SlateDbFs>,
     devices: HashMap<String, NBDDevice>,
+    host: String,
     port: u16,
 }
 
 impl NBDServer {
-    pub fn new(filesystem: Arc<SlateDbFs>, port: u16) -> Self {
+    pub fn new(filesystem: Arc<SlateDbFs>, host: String, port: u16) -> Self {
         Self {
             filesystem,
             devices: HashMap::new(),
+            host,
             port,
         }
     }
@@ -92,8 +94,8 @@ impl NBDServer {
             self.initialize_device(device).await?;
         }
 
-        let listener = TcpListener::bind(format!("127.0.0.1:{}", self.port)).await?;
-        info!("NBD server listening on port {}", self.port);
+        let listener = TcpListener::bind(format!("{}:{}", self.host, self.port)).await?;
+        info!("NBD server listening on {}:{}", self.host, self.port);
 
         loop {
             let (stream, addr) = listener.accept().await?;


### PR DESCRIPTION
This adds support for configurable IP and Port for the NFS TCP socket, with sane defaults.

We needed ZeroFS to allow connections across machines inside our VPC, thus we are making this PR. 