### PR TITLE
feat: add NBD multi-connection support

### DIFF
--- a/src/nbd/protocol.rs
+++ b/src/nbd/protocol.rs
@@ -21,6 +21,7 @@ pub const NBD_FLAG_SEND_FLUSH: u16 = 1 << 2;
 pub const NBD_FLAG_SEND_FUA: u16 = 1 << 3;
 pub const NBD_FLAG_SEND_TRIM: u16 = 1 << 5;
 pub const NBD_FLAG_SEND_WRITE_ZEROES: u16 = 1 << 6;
+pub const NBD_FLAG_CAN_MULTI_CONN: u16 = 1 << 8;
 pub const NBD_FLAG_SEND_CACHE: u16 = 1 << 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, DekuRead, DekuWrite)]
@@ -199,5 +200,6 @@ pub fn get_transmission_flags() -> u16 {
         | NBD_FLAG_SEND_FUA
         | NBD_FLAG_SEND_TRIM
         | NBD_FLAG_SEND_WRITE_ZEROES
+        | NBD_FLAG_CAN_MULTI_CONN
         | NBD_FLAG_SEND_CACHE
 }


### PR DESCRIPTION
Enable multiple concurrent connections to NBD exports by advertising the NBD_FLAG_CAN_MULTI_CONN flag. This allows clients to use the -connections parameter for improved performance.

The server already handles concurrent connections safely through Arc<SlateDbFs>, so this change simply advertises that capability to clients.