### PR TITLE
Fix unclean shutdown detection always appearing on startup

### DIFF
--- a/zerofs/src/main.rs
+++ b/zerofs/src/main.rs
@@ -453,18 +453,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 unreachable!("Stats task should never complete");
             }
             _ = tokio::signal::ctrl_c() => {
-                info!("Received SIGINT, flushing and shutting down gracefully...");
-                fs_arc.db.flush().await?;
+                info!("Received SIGINT, shutting down gracefully...");
                 fs_arc.mark_clean_shutdown().await?;
-                fs_arc.db.flush().await?;
-                fs_arc.db.close().await?;
             }
             _ = sigterm.recv() => {
-                info!("Received SIGTERM, flushing and shutting down gracefully..");
-                fs_arc.db.flush().await?;
+                info!("Received SIGTERM, shutting down gracefully...");
                 fs_arc.mark_clean_shutdown().await?;
-                fs_arc.db.flush().await?;
-                fs_arc.db.close().await?;
             }
         }
     } else {
@@ -485,13 +479,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 unreachable!("Stats task should never complete");
             }
             _ = tokio::signal::ctrl_c() => {
-                info!("Received SIGINT, flushing and shutting down gracefully...");
-                fs_arc.db.flush().await?;
+                info!("Received SIGINT, shutting down gracefully...");
                 fs_arc.mark_clean_shutdown().await?;
             }
             _ = sigterm.recv() => {
-                info!("Received SIGTERM, flushing and shutting down gracefully..");
-                fs_arc.db.flush().await?;
+                info!("Received SIGTERM, shutting down gracefully...");
                 fs_arc.mark_clean_shutdown().await?;
             }
         }


### PR DESCRIPTION
The clean shutdown flag was not being properly persisted when NBD ports were configured, causing recovery to run unnecessarily on every startup.

Refactored mark_clean_shutdown() to include the complete shutdown sequence (flush, mark clean, flush, close) and eliminated code duplication between NBD and non-NBD shutdown paths.

Updated tests to manually set clean shutdown flag instead of calling mark_clean_shutdown() which now closes the database.