### PR TITLE
Add storage provider compatibility check for conditional writes

### DIFF
--- a/zerofs/src/cli/server.rs
+++ b/zerofs/src/cli/server.rs
@@ -209,6 +209,8 @@ async fn initialize_filesystem(settings: &Settings) -> Result<Arc<ZeroFS>> {
         cache_config.root_folder
     );
 
+    crate::storage_compatibility::check_if_match_support(&object_store, &actual_db_path).await?;
+
     let password = settings.storage.encryption_password.clone();
 
     super::password::validate_password(&password)

--- a/zerofs/src/main.rs
+++ b/zerofs/src/main.rs
@@ -11,6 +11,7 @@ mod key_management;
 mod nbd;
 mod nfs;
 mod ninep;
+mod storage_compatibility;
 
 #[cfg(test)]
 mod test_helpers;

--- a/zerofs/src/storage_compatibility.rs
+++ b/zerofs/src/storage_compatibility.rs
@@ -1,0 +1,67 @@
+use futures::StreamExt;
+use object_store::{Error, ObjectStore, PutMode, PutOptions, path::Path};
+use std::sync::Arc;
+use uuid::Uuid;
+
+const TEST_FILE_PREFIX: &str = ".zerofs_compatibility_test_";
+
+pub async fn check_if_match_support(
+    object_store: &Arc<dyn ObjectStore>,
+    db_path: &str,
+) -> anyhow::Result<()> {
+    // Clean up any old test files from previous runs (best effort)
+    let prefix_path = Path::from(db_path).child(TEST_FILE_PREFIX);
+    let mut list = object_store.list(Some(&prefix_path));
+    while let Some(Ok(meta)) = list.next().await {
+        let _ = object_store.delete(&meta.location).await;
+    }
+
+    let test_id = Uuid::new_v4();
+    let test_path = Path::from(db_path).child(format!("{}{}", TEST_FILE_PREFIX, test_id));
+
+    tracing::info!("Checking storage provider compatibility (conditional writes for fencing)...");
+
+    object_store
+        .put(&test_path, "initial".into())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write test file: {e}"))?;
+
+    let result = object_store
+        .put_opts(
+            &test_path,
+            "should_fail".into(),
+            PutOptions::from(PutMode::Create),
+        )
+        .await;
+
+    let _ = object_store.delete(&test_path).await;
+
+    match result {
+        Err(Error::AlreadyExists { .. }) => {
+            tracing::info!("Storage provider compatibility check passed");
+            Ok(())
+        }
+        Ok(_) => Err(anyhow::anyhow!(
+            "Storage provider does not support conditional writes. \
+            PutMode::Create succeeded when it should have failed. \
+            This feature is required for fencing in ZeroFS."
+        )),
+        Err(Error::NotImplemented) => Err(anyhow::anyhow!(
+            "Storage provider does not support conditional writes (PutMode::Create). \
+            This feature is required for fencing in ZeroFS."
+        )),
+        Err(e) => {
+            let error_str = e.to_string().to_lowercase();
+            if error_str.contains("501") || error_str.contains("not implemented") {
+                Err(anyhow::anyhow!(
+                    "Storage provider does not support conditional writes. \
+                    This feature is required for fencing in ZeroFS.\n\n{e}"
+                ))
+            } else {
+                Err(anyhow::anyhow!(
+                    "Storage provider precondition check failed: {e}"
+                ))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Detect early if storage provider supports PutMode::Create (put-if-not-exists) which is required for fencing. Fail fast with clear error message instead of mysterious 501 errors during operation.

Fixes #95