### PR TITLE
Fix NBD option reply protocol compliance

### DIFF
--- a/zerofs/src/nbd/protocol.rs
+++ b/zerofs/src/nbd/protocol.rs
@@ -45,20 +45,27 @@ pub enum NBDCommand {
     Unknown(u16),
 }
 
+pub const NBD_OPT_EXPORT_NAME: u32 = 1;
+pub const NBD_OPT_ABORT: u32 = 2;
+pub const NBD_OPT_LIST: u32 = 3;
+pub const NBD_OPT_INFO: u32 = 6;
+pub const NBD_OPT_GO: u32 = 7;
+pub const NBD_OPT_STRUCTURED_REPLY: u32 = 8;
+
 #[derive(Debug, Clone, Copy, PartialEq, DekuRead, DekuWrite)]
 #[deku(id_type = "u32")]
 pub enum NBDOption {
-    #[deku(id = "1")]
+    #[deku(id = "NBD_OPT_EXPORT_NAME")]
     ExportName,
-    #[deku(id = "2")]
+    #[deku(id = "NBD_OPT_ABORT")]
     Abort,
-    #[deku(id = "3")]
+    #[deku(id = "NBD_OPT_LIST")]
     List,
-    #[deku(id = "6")]
+    #[deku(id = "NBD_OPT_INFO")]
     Info,
-    #[deku(id = "7")]
+    #[deku(id = "NBD_OPT_GO")]
     Go,
-    #[deku(id = "8")]
+    #[deku(id = "NBD_OPT_STRUCTURED_REPLY")]
     StructuredReply,
 }
 


### PR DESCRIPTION
Server was incorrectly using enum discriminants instead of protocol-defined values when sending option replies. This caused FreeBSD NBD clients to reject replies with 'unexpected option' errors.

- Use protocol-defined constants for NBD options (LIST=3, INFO=6, GO=7, etc.)
- Replace enum casting with explicit protocol values in all reply messages
- Define constants to avoid magic numbers and ensure consistency

Should address https://github.com/ryan-moeller/kernel-nbd-client/issues/1