### PR TITLE
Add environment variable to skip compatibility check for single-instance deployments.

### DIFF
--- a/zerofs/src/cli/server.rs
+++ b/zerofs/src/cli/server.rs
@@ -209,7 +209,16 @@ async fn initialize_filesystem(settings: &Settings) -> Result<Arc<ZeroFS>> {
         cache_config.root_folder
     );
 
-    crate::storage_compatibility::check_if_match_support(&object_store, &actual_db_path).await?;
+    if !settings.storage.skip_compatibility_check {
+        crate::storage_compatibility::check_if_match_support(&object_store, &actual_db_path)
+            .await?;
+    } else {
+        tracing::warn!(
+            "Compatibility check skipped per configuration. \
+            WARNING: Running multiple ZeroFS instances on the same storage \
+            backend may cause data corruption!"
+        );
+    }
 
     let password = settings.storage.encryption_password.clone();
 

--- a/zerofs/src/config.rs
+++ b/zerofs/src/config.rs
@@ -34,6 +34,8 @@ pub struct StorageConfig {
     pub url: String,
     #[serde(deserialize_with = "deserialize_expandable_string")]
     pub encryption_password: String,
+    #[serde(default)]
+    pub skip_compatibility_check: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -235,6 +237,7 @@ impl Settings {
             storage: StorageConfig {
                 url: "s3://your-bucket/zerofs-data".to_string(),
                 encryption_password: "${ZEROFS_PASSWORD}".to_string(),
+                skip_compatibility_check: false,
             },
             servers: ServerConfig {
                 nfs: Some(NfsConfig {


### PR DESCRIPTION
Many S3-compatible storage services don't support conditional writes (`PutMode::Create`).  This PR adds `ZEROFS_SINGLE_INSTANCE_MODE` environment variable to skip the compatibility check, allowing to run on these backends when deployed as a single instance.