### PR TITLE
docs: fix value type for allow_http

### DIFF
--- a/documentation/src/app/configuration/page.mdx
+++ b/documentation/src/app/configuration/page.mdx
@@ -49,7 +49,7 @@ access_key_id = "AKIAIOSFODNN7EXAMPLE"
 secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 region = "us-east-1"              # Optional, defaults to us-east-1
 endpoint = "https://s3.amazonaws.com"  # Optional for S3-compatible services
-allow_http = false                # Set to true for non-HTTPS endpoints
+allow_http = "false"                # Set to true for non-HTTPS endpoints
 ```
 
 <Note>
@@ -168,7 +168,7 @@ encryption_password = "secure-password"
 access_key_id = "minioadmin"
 secret_access_key = "minioadmin"
 endpoint = "https://minio.example.com"
-allow_http = true  # Set to true if using HTTP
+allow_http = "true"  # Set to true if using HTTP
 ```
 
 ```toml {{ title: 'Cloudflare R2' }}

--- a/documentation/src/app/quickstart/page.mdx
+++ b/documentation/src/app/quickstart/page.mdx
@@ -145,7 +145,7 @@ encryption_password = "your-secure-password"
 access_key_id = "minioadmin"
 secret_access_key = "minioadmin"
 endpoint = "https://minio.example.com"
-allow_http = true    # For HTTP endpoints
+allow_http = "true"    # For HTTP endpoints
 
 [servers.nfs]
 addresses = ["127.0.0.1:2049"]


### PR DESCRIPTION
i was following the docs to get my initial setup going and noticed that the `allow_http` configuration expects a string type, not bool:

```bash
❯ zerofs run -c zerofs.toml                                                                                                                                                                                
Error: Failed to load config from zerofs.toml

Caused by:
    0: Failed to parse config file: zerofs.toml
    1: TOML parse error at line 58, column 14
          |
       58 | allow_http = true                # Set to true for non-HTTPS endpoints
          |              ^^^^
       invalid type: boolean `true`, expected a string
```

so just wanted to fix this in the docs to keep it consistent