### PR TITLE
Implement stable directory cookies for reliable readdir pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,8 +795,8 @@ This enables persistent storage across workflow runs, shared artifacts between j
 ZeroFS has the following theoretical limits:
 
 - **Maximum file size**: 16 EiB (16 exbibytes = 18.4 exabytes) per file
-- **Maximum number of files create over filesystem lifespan**: 281 trillion (2^48)
-- **Maximum hardlinks per file**: 65,535 (across all directories)
+- **Maximum number of files over filesystem lifespan**: 2^64 (~18 quintillion)
+- **Maximum hardlinks per file**: ~4 billion (2^32)
 - **Maximum filesystem size**: 2^112 bytes
   - = 4,096 geopbytes (where 1 geopbyte = 2^100 bytes)
   - = 4.3 million yottabytes
@@ -804,8 +804,7 @@ ZeroFS has the following theoretical limits:
   - = 4.5 trillion exabytes
 
 These limits come from the filesystem design:
-- File IDs use 48 bits for the inode number and 16 bits for hardlink position
-- File sizes are stored as 64-bit integers
+- Inode IDs and file sizes are stored as 64-bit integers
 - The chunking system uses 256KB blocks with 64-bit indexing
 
 In practice, you'll encounter other constraints well before these theoretical limits, such as S3 provider limits, performance considerations with billions of objects, or simply running out of money.

--- a/zerofs/Cargo.lock
+++ b/zerofs/Cargo.lock
@@ -4095,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "zerofs_nfsserve"
-version = "0.15.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1a98071b31b9687c05411a75df5a55a7a76c5af85cb3bb04de5efef26755c7"
+checksum = "45d3372ac10bc2659da1e217875c37cae46714be5af4be92e61753e641851554"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/zerofs/Cargo.toml
+++ b/zerofs/Cargo.toml
@@ -27,7 +27,7 @@ slatedb = { version = "0.9.2", features = ["wal_disable"] }
 foyer-memory = "0.20.1"
 fastant = "0.1.11"
 tikv-jemallocator = { version = "0.6.1", features = ["background_threads"] }
-zerofs_nfsserve = "0.15"
+zerofs_nfsserve = "0.17.1"
 tokio = { version = "1.48", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 async-trait = "0.1"

--- a/zerofs/src/fs/mod.rs
+++ b/zerofs/src/fs/mod.rs
@@ -33,7 +33,7 @@ use self::permissions::{
     AccessMode, Credentials, can_set_times, check_access, check_ownership, check_sticky_bit_delete,
     validate_mode,
 };
-use self::store::inode::{EncodedFileId, MAX_HARDLINKS_PER_INODE};
+use self::store::inode::MAX_HARDLINKS_PER_INODE;
 use self::types::{
     AuthContext, DirEntry, FileAttributes, FileType, InodeWithId, ReadDirResult, SetAttributes,
     SetGid, SetMode, SetSize, SetTime, SetUid,
@@ -525,7 +525,7 @@ impl ZeroFS {
                     return Err(FsError::Exists);
                 }
 
-                let file_id = self.inode_store.allocate()?;
+                let file_id = self.inode_store.allocate();
                 debug!(
                     "Allocated inode {} for file {}",
                     file_id,
@@ -561,10 +561,15 @@ impl ZeroFS {
                 };
 
                 let mut txn = self.db.new_transaction()?;
+                let cookie = self
+                    .directory_store
+                    .allocate_cookie(dirid, &mut txn)
+                    .await?;
 
                 self.inode_store
                     .save(&mut txn, file_id, &Inode::File(file_inode.clone()))?;
-                self.directory_store.add(&mut txn, dirid, name, file_id);
+                self.directory_store
+                    .add(&mut txn, dirid, name, file_id, cookie);
 
                 dir.entry_count += 1;
                 dir.mtime = now_sec;
@@ -796,7 +801,7 @@ impl ZeroFS {
                     return Err(FsError::Exists);
                 }
 
-                let new_dir_id = self.inode_store.allocate()?;
+                let new_dir_id = self.inode_store.allocate();
 
                 let (now_sec, now_nsec) = get_current_time();
 
@@ -852,13 +857,18 @@ impl ZeroFS {
                 };
 
                 let mut txn = self.db.new_transaction()?;
+                let cookie = self
+                    .directory_store
+                    .allocate_cookie(dirid, &mut txn)
+                    .await?;
 
                 self.inode_store.save(
                     &mut txn,
                     new_dir_id,
                     &Inode::Directory(new_dir_inode.clone()),
                 )?;
-                self.directory_store.add(&mut txn, dirid, name, new_dir_id);
+                self.directory_store
+                    .add(&mut txn, dirid, name, new_dir_id, cookie);
 
                 dir.entry_count += 1;
                 if dir.nlink == u32::MAX {
@@ -907,42 +917,32 @@ impl ZeroFS {
         start_after: InodeId,
         max_entries: usize,
     ) -> Result<ReadDirResult, FsError> {
-        debug!(
-            "readdir: dirid={}, start_after={}, max_entries={}",
-            dirid, start_after, max_entries
-        );
-
         let dir_inode = self.get_inode_cached(dirid).await?;
 
         let creds = Credentials::from_auth_context(auth);
         check_access(&dir_inode, &creds, AccessMode::Read)?;
 
+        use crate::fs::store::directory::{COOKIE_DOT, COOKIE_DOTDOT};
+
         match &dir_inode {
             Inode::Directory(dir) => {
                 let mut entries = Vec::new();
-                let mut inode_positions = std::collections::HashMap::new();
 
-                let (start_inode, start_position) = if start_after == 0 {
-                    (0, 0)
-                } else {
-                    EncodedFileId::from(start_after).decode()
-                };
-
-                let skip_special = start_after != 0;
-
-                if !skip_special {
-                    debug!("readdir: adding . entry for current directory");
+                // Handle . and .. based on start_after cookie
+                if start_after < COOKIE_DOT {
                     entries.push(DirEntry {
-                        fileid: EncodedFileId::new(dirid, 0)?.as_raw(),
+                        fileid: dirid,
                         name: b".".to_vec(),
                         attr: InodeWithId {
                             inode: &dir_inode,
                             id: dirid,
                         }
                         .into(),
+                        cookie: COOKIE_DOT,
                     });
+                }
 
-                    debug!("readdir: adding .. entry for parent directory");
+                if start_after < COOKIE_DOTDOT {
                     let parent_id = if dirid == 0 { 0 } else { dir.parent };
                     let parent_attr = if parent_id == dirid {
                         InodeWithId {
@@ -965,74 +965,50 @@ impl ZeroFS {
                         }
                     };
                     entries.push(DirEntry {
-                        fileid: EncodedFileId::new(parent_id, 0)?.as_raw(),
+                        fileid: parent_id,
                         name: b"..".to_vec(),
                         attr: parent_attr,
+                        cookie: COOKIE_DOTDOT,
                     });
                 }
 
-                let iter = if start_after == 0 {
+                // Get regular entries, starting after the given cookie
+                let iter = if start_after < COOKIE_DOTDOT {
                     self.directory_store.list(dirid).await?
                 } else {
-                    self.directory_store.list_from(dirid, start_inode).await?
+                    self.directory_store.list_from(dirid, start_after).await?
                 };
                 pin_mut!(iter);
 
                 let mut dir_entries = Vec::new();
-                let mut resuming = start_after != 0;
                 let mut has_more = false;
 
                 while let Some(result) = iter.next().await {
                     if dir_entries.len() >= max_entries - entries.len() {
-                        debug!("readdir: reached max_entries limit, found one more entry");
                         has_more = true;
                         break;
                     }
-
                     let entry = result?;
-                    let inode_id = entry.inode_id;
-                    let filename = entry.name;
-
-                    if resuming {
-                        if inode_id == start_inode {
-                            let pos = inode_positions.entry(inode_id).or_insert(0);
-                            if *pos <= start_position {
-                                *pos += 1;
-                                continue;
-                            }
-                        } else if inode_id < start_inode {
-                            continue;
-                        }
-                        resuming = false;
-                    }
-
-                    debug!(
-                        "readdir: found entry {} (inode {})",
-                        String::from_utf8_lossy(&filename),
-                        inode_id
-                    );
-                    dir_entries.push((inode_id, filename));
+                    dir_entries.push((entry.inode_id, entry.name, entry.cookie));
                 }
 
                 const BUFFER_SIZE: usize = 256;
 
-                let inode_futures =
-                    stream::iter(dir_entries.into_iter()).map(|(inode_id, name)| async move {
-                        debug!("readdir: loading inode {} for entry '{}'", inode_id, String::from_utf8_lossy(&name));
+                let inode_futures = stream::iter(dir_entries.into_iter()).map(
+                    |(inode_id, name, cookie)| async move {
                         match self.get_inode_cached(inode_id).await {
-                            Ok(inode) => {
-                                debug!("readdir: loaded inode {} successfully", inode_id);
-                                Ok::<Option<(u64, Vec<u8>, Inode)>, FsError>(Some((inode_id, name, inode)))
-                            }
+                            Ok(inode) => Ok::<_, FsError>(Some((inode_id, name, inode, cookie))),
                             Err(e) => {
                                 tracing::error!(
-                                    "readdir: skipping entry '{}' (inode {}) due to error: {:?}. Database may be corrupted.",
-                                    String::from_utf8_lossy(&name), inode_id, e
+                                    "readdir: skipping entry (inode {}) due to error: {:?}",
+                                    inode_id,
+                                    e
                                 );
                                 Ok(None)
                             }
                         }
-                    });
+                    },
+                );
 
                 let loaded_entries: Vec<_> = inode_futures
                     .buffered(BUFFER_SIZE)
@@ -1044,36 +1020,26 @@ impl ZeroFS {
                     .flatten()
                     .collect();
 
-                for (inode_id, name, inode) in loaded_entries {
-                    let position = inode_positions.entry(inode_id).or_insert(0);
-                    let encoded_id = EncodedFileId::new(inode_id, *position)?.as_raw();
-                    *position += 1;
-
+                for (inode_id, name, inode, cookie) in loaded_entries {
                     entries.push(DirEntry {
-                        fileid: encoded_id,
+                        fileid: inode_id,
                         name,
                         attr: InodeWithId {
                             inode: &inode,
                             id: inode_id,
                         }
                         .into(),
+                        cookie,
                     });
-                    debug!("readdir: added entry with encoded id {}", encoded_id);
                 }
-
-                let end = !has_more;
-
-                let result = ReadDirResult { end, entries };
-                debug!(
-                    "readdir: returning {} entries, end={}",
-                    result.entries.len(),
-                    result.end
-                );
 
                 self.stats.read_operations.fetch_add(1, Ordering::Relaxed);
                 self.stats.total_operations.fetch_add(1, Ordering::Relaxed);
 
-                Ok(result)
+                Ok(ReadDirResult {
+                    entries,
+                    end: !has_more,
+                })
             }
             _ => Err(FsError::NotDirectory),
         }
@@ -1116,7 +1082,7 @@ impl ZeroFS {
             return Err(FsError::Exists);
         }
 
-        let new_id = self.inode_store.allocate()?;
+        let new_id = self.inode_store.allocate();
 
         let mode = match &attr.mode {
             SetMode::Set(m) => *m | 0o120000,
@@ -1150,9 +1116,14 @@ impl ZeroFS {
         });
 
         let mut txn = self.db.new_transaction()?;
+        let cookie = self
+            .directory_store
+            .allocate_cookie(dirid, &mut txn)
+            .await?;
 
         self.inode_store.save(&mut txn, new_id, &symlink_inode)?;
-        self.directory_store.add(&mut txn, dirid, linkname, new_id);
+        self.directory_store
+            .add(&mut txn, dirid, linkname, new_id, cookie);
 
         dir.entry_count += 1;
         dir.mtime = now_sec;
@@ -1235,13 +1206,17 @@ impl ZeroFS {
         }
 
         let mut txn = self.db.new_transaction()?;
+        let cookie = self
+            .directory_store
+            .allocate_cookie(linkdirid, &mut txn)
+            .await?;
         self.directory_store
-            .add(&mut txn, linkdirid, linkname, fileid);
+            .add(&mut txn, linkdirid, linkname, fileid, cookie);
 
         let (now_sec, now_nsec) = get_current_time();
         match &mut file_inode {
             Inode::File(file) => {
-                if file.nlink >= MAX_HARDLINKS_PER_INODE {
+                if file.nlink == MAX_HARDLINKS_PER_INODE {
                     return Err(FsError::TooManyLinks);
                 }
                 file.nlink += 1;
@@ -1256,7 +1231,7 @@ impl ZeroFS {
             | Inode::Socket(special)
             | Inode::CharDevice(special)
             | Inode::BlockDevice(special) => {
-                if special.nlink >= MAX_HARDLINKS_PER_INODE {
+                if special.nlink == MAX_HARDLINKS_PER_INODE {
                     return Err(FsError::TooManyLinks);
                 }
                 special.nlink += 1;
@@ -1725,7 +1700,7 @@ impl ZeroFS {
                     return Err(FsError::Exists);
                 }
 
-                let special_id = self.inode_store.allocate()?;
+                let special_id = self.inode_store.allocate();
                 let (now_sec, now_nsec) = get_current_time();
 
                 let base_mode = match ftype {
@@ -1771,9 +1746,14 @@ impl ZeroFS {
                 };
 
                 let mut txn = self.db.new_transaction()?;
+                let cookie = self
+                    .directory_store
+                    .allocate_cookie(dirid, &mut txn)
+                    .await?;
 
                 self.inode_store.save(&mut txn, special_id, &inode)?;
-                self.directory_store.add(&mut txn, dirid, name, special_id);
+                self.directory_store
+                    .add(&mut txn, dirid, name, special_id, cookie);
 
                 dir.entry_count += 1;
                 dir.mtime = now_sec;
@@ -1817,7 +1797,10 @@ impl ZeroFS {
 
         let creds = Credentials::from_auth_context(auth);
 
-        let file_id = self.directory_store.get(dirid, name).await?;
+        let (file_id, cookie) = self
+            .directory_store
+            .get_entry_with_cookie(dirid, name)
+            .await?;
 
         let _guards = self
             .lock_manager
@@ -1834,8 +1817,11 @@ impl ZeroFS {
         }
 
         // Re-check inside lock to verify entry still points to same inode
-        let verified_id = self.directory_store.get(dirid, name).await?;
-        if verified_id != file_id {
+        let (verified_id, verified_cookie) = self
+            .directory_store
+            .get_entry_with_cookie(dirid, name)
+            .await?;
+        if verified_id != file_id || verified_cookie != cookie {
             return Err(FsError::NotFound);
         }
 
@@ -1911,7 +1897,7 @@ impl ZeroFS {
                     }
                 }
 
-                self.directory_store.remove(&mut txn, dirid, name, file_id);
+                self.directory_store.remove(&mut txn, dirid, name, cookie);
 
                 dir.entry_count = dir.entry_count.saturating_sub(1);
                 dir.mtime = now_sec;
@@ -2006,17 +1992,25 @@ impl ZeroFS {
         let creds = Credentials::from_auth_context(auth);
 
         // Look up all inode IDs without holding any locks
-        let source_inode_id = self.directory_store.get(from_dirid, from_name).await?;
+        let (source_inode_id, source_cookie) = self
+            .directory_store
+            .get_entry_with_cookie(from_dirid, from_name)
+            .await?;
 
         if to_dirid == source_inode_id {
             return Err(FsError::InvalidArgument);
         }
 
-        let target_inode_id = match self.directory_store.get(to_dirid, to_name).await {
-            Ok(id) => Some(id),
+        let target_entry = match self
+            .directory_store
+            .get_entry_with_cookie(to_dirid, to_name)
+            .await
+        {
+            Ok((id, cookie)) => Some((id, cookie)),
             Err(FsError::NotFound) => None,
             Err(e) => return Err(e),
         };
+        let target_inode_id = target_entry.map(|(id, _)| id);
 
         let mut all_inodes_to_lock = vec![from_dirid, source_inode_id];
         if from_dirid != to_dirid {
@@ -2032,19 +2026,27 @@ impl ZeroFS {
             .await;
 
         // Re-verify inside lock that entries still point to same inodes
-        let verified_source_id = self.directory_store.get(from_dirid, from_name).await?;
-        if verified_source_id != source_inode_id {
+        let (verified_source_id, verified_source_cookie) = self
+            .directory_store
+            .get_entry_with_cookie(from_dirid, from_name)
+            .await?;
+        if verified_source_id != source_inode_id || verified_source_cookie != source_cookie {
             return Err(FsError::StaleHandle);
         }
 
-        let verified_target_id = match self.directory_store.get(to_dirid, to_name).await {
-            Ok(id) => Some(id),
+        let verified_target_entry = match self
+            .directory_store
+            .get_entry_with_cookie(to_dirid, to_name)
+            .await
+        {
+            Ok((id, cookie)) => Some((id, cookie)),
             Err(FsError::NotFound) => None,
             Err(e) => return Err(e),
         };
-        if verified_target_id != target_inode_id {
+        if verified_target_entry.map(|(id, _)| id) != target_inode_id {
             return Err(FsError::StaleHandle);
         }
+        let target_cookie = verified_target_entry.map(|(_, cookie)| cookie);
 
         let mut source_inode = self.get_inode_cached(source_inode_id).await?;
         if matches!(source_inode, Inode::Directory(_))
@@ -2196,13 +2198,17 @@ impl ZeroFS {
             }
 
             self.directory_store
-                .remove(&mut txn, to_dirid, to_name, target_id);
+                .remove(&mut txn, to_dirid, to_name, target_cookie.unwrap());
         }
 
         self.directory_store
-            .remove(&mut txn, from_dirid, from_name, source_inode_id);
+            .remove(&mut txn, from_dirid, from_name, source_cookie);
+        let new_cookie = self
+            .directory_store
+            .allocate_cookie(to_dirid, &mut txn)
+            .await?;
         self.directory_store
-            .add(&mut txn, to_dirid, to_name, source_inode_id);
+            .add(&mut txn, to_dirid, to_name, source_inode_id, new_cookie);
 
         if from_dirid != to_dirid {
             match &mut source_inode {
@@ -2334,7 +2340,6 @@ impl ZeroFS {
 mod tests {
     use super::*;
     use crate::fs::inode::FileInode;
-    use crate::fs::store::inode::{MAX_HARDLINKS_PER_INODE, MAX_INODE_ID};
     use crate::test_helpers::test_helpers_mod::test_auth;
 
     fn test_creds() -> Credentials {
@@ -2362,9 +2367,9 @@ mod tests {
     async fn test_allocate_inode() {
         let fs = ZeroFS::new_in_memory().await.unwrap();
 
-        let inode1 = fs.inode_store.allocate().unwrap();
-        let inode2 = fs.inode_store.allocate().unwrap();
-        let inode3 = fs.inode_store.allocate().unwrap();
+        let inode1 = fs.inode_store.allocate();
+        let inode2 = fs.inode_store.allocate();
+        let inode3 = fs.inode_store.allocate();
 
         assert_ne!(inode1, 0);
         assert_ne!(inode2, 0);
@@ -2394,7 +2399,7 @@ mod tests {
         };
 
         let inode = Inode::File(file_inode.clone());
-        let inode_id = fs.inode_store.allocate().unwrap();
+        let inode_id = fs.inode_store.allocate();
 
         let mut txn = fs.db.new_transaction().unwrap();
         fs.inode_store.save(&mut txn, inode_id, &inode).unwrap();
@@ -2464,21 +2469,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_max_inode_id_limit() {
-        let fs = ZeroFS::new_in_memory().await.unwrap();
-
-        fs.inode_store.set_next_id_for_testing(MAX_INODE_ID);
-
-        let id = fs.inode_store.allocate().unwrap();
-        assert_eq!(id, MAX_INODE_ID);
-
-        let result = fs.inode_store.allocate();
-        assert!(matches!(result, Err(FsError::NoSpace)));
-
-        assert!(fs.inode_store.next_id() > MAX_INODE_ID);
-    }
-
-    #[tokio::test]
     async fn test_read_only_mode_operations() {
         use slatedb::DbBuilder;
         use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
@@ -2519,7 +2509,7 @@ mod tests {
         .await
         .unwrap();
 
-        let test_inode_id = fs_rw.inode_store.allocate().unwrap();
+        let test_inode_id = fs_rw.inode_store.allocate();
         let file_inode = FileInode {
             size: 2048,
             mtime: 1234567890,
@@ -3323,7 +3313,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_readdir_encoding_with_hardlinks() {
+    async fn test_readdir_with_hardlinks_stable_cookies() {
         let fs = ZeroFS::new_in_memory().await.unwrap();
 
         // Create files with hardlinks
@@ -3341,7 +3331,7 @@ mod tests {
             .unwrap();
 
         // Create another file
-        let (_file2_id, _) = fs
+        let (file2_id, _) = fs
             .create(&test_creds(), 0, b"file2.txt", &SetAttributes::default())
             .await
             .unwrap();
@@ -3350,25 +3340,26 @@ mod tests {
         let result1 = fs.readdir(&(&test_auth()).into(), 0, 0, 10).await.unwrap();
         assert_eq!(result1.entries.len(), 6); // . .. file1.txt hardlink1.txt hardlink2.txt file2.txt
 
-        // Check that hardlinks have different encoded fileids
-        let file1_encoded = result1.entries[2].fileid;
-        let hardlink1_encoded = result1.entries[3].fileid;
-        let hardlink2_encoded = result1.entries[4].fileid;
+        // With stable cookies, hardlinks have the SAME fileid (raw inode) but DIFFERENT cookies
+        let file1_entry = &result1.entries[2];
+        let hardlink1_entry = &result1.entries[3];
+        let hardlink2_entry = &result1.entries[4];
+        let file2_entry = &result1.entries[5];
 
-        // Decode to verify they point to the same inode
-        let (file1_inode, file1_pos) = EncodedFileId::from(file1_encoded).decode();
-        let (hardlink1_inode, hardlink1_pos) = EncodedFileId::from(hardlink1_encoded).decode();
-        let (hardlink2_inode, hardlink2_pos) = EncodedFileId::from(hardlink2_encoded).decode();
+        // All hardlinks point to the same inode
+        assert_eq!(file1_entry.fileid, file1_id);
+        assert_eq!(hardlink1_entry.fileid, file1_id);
+        assert_eq!(hardlink2_entry.fileid, file1_id);
+        assert_eq!(file2_entry.fileid, file2_id);
 
-        assert_eq!(file1_inode, hardlink1_inode);
-        assert_eq!(file1_inode, hardlink2_inode);
-        assert_eq!(file1_pos, 0);
-        assert_eq!(hardlink1_pos, 1);
-        assert_eq!(hardlink2_pos, 2);
+        // Cookies are unique and stable for pagination
+        assert_ne!(file1_entry.cookie, hardlink1_entry.cookie);
+        assert_ne!(hardlink1_entry.cookie, hardlink2_entry.cookie);
+        assert_ne!(hardlink2_entry.cookie, file2_entry.cookie);
 
-        // Test pagination - start after the first hardlink
+        // Test pagination using cookies - start after the first hardlink
         let result2 = fs
-            .readdir(&(&test_auth()).into(), 0, hardlink1_encoded, 10)
+            .readdir(&(&test_auth()).into(), 0, hardlink1_entry.cookie, 10)
             .await
             .unwrap();
         assert_eq!(result2.entries.len(), 2); // hardlink2.txt file2.txt

--- a/zerofs/src/fs/store/directory.rs
+++ b/zerofs/src/fs/store/directory.rs
@@ -8,10 +8,18 @@ use futures::StreamExt;
 use std::pin::Pin;
 use std::sync::Arc;
 
+/// Reserved cookie values
+/// 0 is reserved for "start from beginning" (not a valid entry cookie)
+pub const COOKIE_DOT: u64 = 1;
+pub const COOKIE_DOTDOT: u64 = 2;
+/// First cookie value for regular entries
+pub const COOKIE_FIRST_ENTRY: u64 = 3;
+
 #[derive(Debug, Clone)]
 pub struct DirEntryInfo {
     pub name: Vec<u8>,
     pub inode_id: InodeId,
+    pub cookie: u64,
 }
 
 #[derive(Clone)]
@@ -34,7 +42,23 @@ impl DirectoryStore {
             .map_err(|_| FsError::IoError)?
             .ok_or(FsError::NotFound)?;
 
-        KeyCodec::decode_dir_entry(&entry_data)
+        let (inode_id, _cookie) = KeyCodec::decode_dir_entry(&entry_data)?;
+        Ok(inode_id)
+    }
+
+    pub async fn allocate_cookie(
+        &self,
+        dir_id: InodeId,
+        txn: &mut EncryptedTransaction,
+    ) -> Result<u64, FsError> {
+        let counter_key = KeyCodec::dir_cookie_counter_key(dir_id);
+        let current = match self.db.get_bytes(&counter_key).await {
+            Ok(Some(data)) => KeyCodec::decode_counter(&data)?,
+            Ok(None) => COOKIE_FIRST_ENTRY,
+            Err(_) => return Err(FsError::IoError),
+        };
+        txn.put_bytes(&counter_key, KeyCodec::encode_counter(current + 1));
+        Ok(current)
     }
 
     pub async fn exists(&self, dir_id: InodeId, name: &[u8]) -> Result<bool, FsError> {
@@ -65,16 +89,23 @@ impl DirectoryStore {
 
         Ok(Box::pin(futures::stream::unfold(iter, |mut iter| async {
             match iter.next().await {
-                Some(Ok((key, _value))) => match KeyCodec::parse_key(&key) {
-                    ParsedKey::DirScan { entry_id, name } => Some((
-                        Ok(DirEntryInfo {
-                            name,
-                            inode_id: entry_id,
-                        }),
-                        iter,
-                    )),
-                    _ => Some((Err(FsError::InvalidData), iter)),
-                },
+                Some(Ok((key, value))) => {
+                    let cookie = match KeyCodec::parse_key(&key) {
+                        ParsedKey::DirScan { cookie } => cookie,
+                        _ => return Some((Err(FsError::InvalidData), iter)),
+                    };
+                    match KeyCodec::decode_dir_scan_value(&value) {
+                        Ok((inode_id, name)) => Some((
+                            Ok(DirEntryInfo {
+                                name,
+                                inode_id,
+                                cookie,
+                            }),
+                            iter,
+                        )),
+                        Err(e) => Some((Err(e), iter)),
+                    }
+                }
                 Some(Err(_)) => Some((Err(FsError::IoError), iter)),
                 None => None,
             }
@@ -84,10 +115,10 @@ impl DirectoryStore {
     pub async fn list_from(
         &self,
         dir_id: InodeId,
-        resume_from: InodeId,
+        resume_after_cookie: u64,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<DirEntryInfo, FsError>> + Send + '_>>, FsError>
     {
-        let start_key = KeyCodec::dir_scan_resume_key(dir_id, resume_from);
+        let start_key = KeyCodec::dir_scan_resume_key(dir_id, resume_after_cookie);
         let end_key = KeyCodec::dir_scan_end_key(dir_id);
 
         let iter = self
@@ -98,16 +129,23 @@ impl DirectoryStore {
 
         Ok(Box::pin(futures::stream::unfold(iter, |mut iter| async {
             match iter.next().await {
-                Some(Ok((key, _value))) => match KeyCodec::parse_key(&key) {
-                    ParsedKey::DirScan { entry_id, name } => Some((
-                        Ok(DirEntryInfo {
-                            name,
-                            inode_id: entry_id,
-                        }),
-                        iter,
-                    )),
-                    _ => Some((Err(FsError::InvalidData), iter)),
-                },
+                Some(Ok((key, value))) => {
+                    let cookie = match KeyCodec::parse_key(&key) {
+                        ParsedKey::DirScan { cookie } => cookie,
+                        _ => return Some((Err(FsError::InvalidData), iter)),
+                    };
+                    match KeyCodec::decode_dir_scan_value(&value) {
+                        Ok((inode_id, name)) => Some((
+                            Ok(DirEntryInfo {
+                                name,
+                                inode_id,
+                                cookie,
+                            }),
+                            iter,
+                        )),
+                        Err(e) => Some((Err(e), iter)),
+                    }
+                }
                 Some(Err(_)) => Some((Err(FsError::IoError), iter)),
                 None => None,
             }
@@ -120,12 +158,13 @@ impl DirectoryStore {
         dir_id: InodeId,
         name: &[u8],
         entry_id: InodeId,
+        cookie: u64,
     ) {
         let entry_key = KeyCodec::dir_entry_key(dir_id, name);
-        txn.put_bytes(&entry_key, KeyCodec::encode_dir_entry(entry_id));
+        txn.put_bytes(&entry_key, KeyCodec::encode_dir_entry(entry_id, cookie));
 
-        let scan_key = KeyCodec::dir_scan_key(dir_id, entry_id, name);
-        txn.put_bytes(&scan_key, KeyCodec::encode_dir_entry(entry_id));
+        let scan_key = KeyCodec::dir_scan_key(dir_id, cookie);
+        txn.put_bytes(&scan_key, KeyCodec::encode_dir_scan_value(entry_id, name));
     }
 
     pub fn remove(
@@ -133,12 +172,29 @@ impl DirectoryStore {
         txn: &mut EncryptedTransaction,
         dir_id: InodeId,
         name: &[u8],
-        entry_id: InodeId,
+        cookie: u64,
     ) {
         let entry_key = KeyCodec::dir_entry_key(dir_id, name);
         txn.delete_bytes(&entry_key);
 
-        let scan_key = KeyCodec::dir_scan_key(dir_id, entry_id, name);
+        let scan_key = KeyCodec::dir_scan_key(dir_id, cookie);
         txn.delete_bytes(&scan_key);
+    }
+
+    pub async fn get_entry_with_cookie(
+        &self,
+        dir_id: InodeId,
+        name: &[u8],
+    ) -> Result<(InodeId, u64), FsError> {
+        let entry_key = KeyCodec::dir_entry_key(dir_id, name);
+
+        let entry_data = self
+            .db
+            .get_bytes(&entry_key)
+            .await
+            .map_err(|_| FsError::IoError)?
+            .ok_or(FsError::NotFound)?;
+
+        KeyCodec::decode_dir_entry(&entry_data)
     }
 }

--- a/zerofs/src/fs/store/inode.rs
+++ b/zerofs/src/fs/store/inode.rs
@@ -5,60 +5,8 @@ use crate::fs::key_codec::KeyCodec;
 use bytes::Bytes;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use zerofs_nfsserve::nfs::fileid3;
 
-/// Maximum inode ID (48-bit limit for encoding scheme)
-pub const MAX_INODE_ID: u64 = (1u64 << 48) - 1;
-
-/// Maximum hardlinks per inode (16-bit limit for position encoding)
-pub const MAX_HARDLINKS_PER_INODE: u32 = u16::MAX as u32;
-
-/// Encoded file ID: High 48 bits = inode ID, Low 16 bits = hardlink position
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct EncodedFileId(u64);
-
-impl EncodedFileId {
-    pub fn new(inode_id: u64, position: u16) -> Result<Self, FsError> {
-        if inode_id > MAX_INODE_ID {
-            return Err(FsError::InvalidData);
-        }
-        Ok(Self((inode_id << 16) | (position as u64)))
-    }
-
-    pub fn from_inode(inode_id: u64) -> Result<Self, FsError> {
-        Self::new(inode_id, 0)
-    }
-
-    pub fn decode(self) -> (u64, u16) {
-        let inode = self.0 >> 16;
-        let position = (self.0 & 0xFFFF) as u16;
-        (inode, position)
-    }
-
-    pub fn as_raw(self) -> u64 {
-        self.0
-    }
-
-    pub fn inode_id(self) -> u64 {
-        self.0 >> 16
-    }
-
-    pub fn position(self) -> u16 {
-        (self.0 & 0xFFFF) as u16
-    }
-}
-
-impl From<fileid3> for EncodedFileId {
-    fn from(id: fileid3) -> Self {
-        Self(id)
-    }
-}
-
-impl From<EncodedFileId> for fileid3 {
-    fn from(id: EncodedFileId) -> Self {
-        id.0
-    }
-}
+pub const MAX_HARDLINKS_PER_INODE: u32 = u32::MAX;
 
 #[derive(Clone)]
 pub struct InodeStore {
@@ -74,15 +22,8 @@ impl InodeStore {
         }
     }
 
-    pub fn allocate(&self) -> Result<InodeId, FsError> {
-        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
-
-        if id > MAX_INODE_ID {
-            self.next_id.store(MAX_INODE_ID + 2, Ordering::SeqCst);
-            return Err(FsError::NoSpace);
-        }
-
-        Ok(id)
+    pub fn allocate(&self) -> InodeId {
+        self.next_id.fetch_add(1, Ordering::SeqCst)
     }
 
     pub fn next_id(&self) -> u64 {
@@ -150,62 +91,5 @@ impl InodeStore {
     #[cfg(test)]
     pub fn set_next_id_for_testing(&self, id: u64) {
         self.next_id.store(id, Ordering::SeqCst);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_encoded_file_id() {
-        let encoded = EncodedFileId::from(0u64);
-        let (inode, pos) = encoded.decode();
-        assert_eq!(inode, 0);
-        assert_eq!(pos, 0);
-
-        let encoded = EncodedFileId::new(42, 0).unwrap();
-        assert_eq!(encoded.inode_id(), 42);
-        assert_eq!(encoded.position(), 0);
-        let (inode, pos) = encoded.decode();
-        assert_eq!(inode, 42);
-        assert_eq!(pos, 0);
-
-        let encoded = EncodedFileId::new(100, 5).unwrap();
-        assert_eq!(encoded.inode_id(), 100);
-        assert_eq!(encoded.position(), 5);
-        let (inode, pos) = encoded.decode();
-        assert_eq!(inode, 100);
-        assert_eq!(pos, 5);
-
-        let encoded = EncodedFileId::new(1000, 65535).unwrap();
-        let (inode, pos) = encoded.decode();
-        assert_eq!(inode, 1000);
-        assert_eq!(pos, 65535);
-
-        let encoded = EncodedFileId::new(MAX_INODE_ID, 0).unwrap();
-        let (inode, pos) = encoded.decode();
-        assert_eq!(inode, MAX_INODE_ID);
-        assert_eq!(pos, 0);
-
-        let raw_value = (42u64 << 16) | 5;
-        let from_raw = EncodedFileId::from(raw_value);
-        assert_eq!(from_raw.inode_id(), 42);
-        assert_eq!(from_raw.position(), 5);
-        assert_eq!(from_raw.as_raw(), raw_value);
-    }
-
-    #[test]
-    fn test_encoded_file_id_max_values() {
-        let encoded = EncodedFileId::new(MAX_INODE_ID, u16::MAX).unwrap();
-        assert_eq!(encoded.inode_id(), MAX_INODE_ID);
-        assert_eq!(encoded.position(), u16::MAX);
-    }
-
-    #[test]
-    fn test_encoded_file_id_inode_overflow() {
-        let overflow_id = MAX_INODE_ID + 1;
-        let result = EncodedFileId::new(overflow_id, 0);
-        assert!(result.is_err());
     }
 }

--- a/zerofs/src/fs/types.rs
+++ b/zerofs/src/fs/types.rs
@@ -466,6 +466,7 @@ pub struct DirEntry {
     pub fileid: InodeId,
     pub name: Vec<u8>,
     pub attr: FileAttributes,
+    pub cookie: u64,
 }
 
 #[derive(Debug, Clone)]

--- a/zerofs/src/nbd/server.rs
+++ b/zerofs/src/nbd/server.rs
@@ -12,7 +12,6 @@ use super::protocol::{
 use crate::fs::ZeroFS;
 use crate::fs::errors::FsError;
 use crate::fs::inode::Inode;
-use crate::fs::store::inode::EncodedFileId;
 use crate::fs::types::AuthContext;
 use bytes::BytesMut;
 use deku::prelude::*;
@@ -186,13 +185,10 @@ impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin> NBDSession<R, W> {
                 continue;
             }
 
-            let encoded_id = EncodedFileId::from(entry.fileid);
-            let real_id = encoded_id.inode_id();
-
             let inode = self
                 .filesystem
                 .inode_store
-                .get(real_id)
+                .get(entry.fileid)
                 .await
                 .map_err(|e| {
                     NBDError::Io(std::io::Error::other(format!(

--- a/zerofs/src/ninep/handler.rs
+++ b/zerofs/src/ninep/handler.rs
@@ -428,7 +428,7 @@ impl NinePHandler {
 
                     for entry in result.entries {
                         if entry.name == b"." || entry.name == b".." {
-                            cookie = entry.fileid;
+                            cookie = entry.cookie;
                             continue;
                         }
 
@@ -444,7 +444,7 @@ impl NinePHandler {
                             current_offset += 1;
                         }
 
-                        cookie = entry.fileid;
+                        cookie = entry.cookie;
                     }
 
                     if was_end {


### PR DESCRIPTION
Replace position-based cookies with monotonic per-directory counters to fix readdir returning duplicates/missing entries during concurrent directory modifications.