### PR TITLE
Add support for separate WAL object store

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,20 @@ Both instances access the same object storage backend.
 
 The compactor uses the same configuration file and respects `[lsm].max_concurrent_compactions` for parallelism.
 
+### Separate WAL Object Store
+
+Every `fsync` writes to the WAL, so fsync latency equals the latency of the WAL's backing store. By default the WAL goes to the same S3 bucket as everything else. You can point it at a separate, lower-latency store instead — local NVMe, S3 Express One-Zone, a nearby S3-compatible service, etc.
+
+```toml
+[wal]
+url = "file:///mnt/nvme/zerofs-wal"
+```
+
+The `[wal]` section supports its own `[wal.aws]`, `[wal.azure]`, and `[wal.gcp]` credential blocks, independent from the main storage credentials. If no `[wal]` section is present, the WAL is written to the main object store.
+
+Whether you use a separate WAL store is decided at filesystem creation time. The underlying storage engine records this in its manifest, so you cannot add or remove a separate WAL store on an existing filesystem.
+
+You can move the WAL to a different location by updating the `[wal]` URL and credentials, but you must manually migrate the WAL files from the old store to the new one before starting ZeroFS.
 
 ### Encryption
 

--- a/documentation/src/app/configuration/page.mdx
+++ b/documentation/src/app/configuration/page.mdx
@@ -222,6 +222,21 @@ Consider tuning these parameters if you're experiencing:
 - **CPU / Network underutilization**: Increase `max_concurrent_compactions` on high-core systems
 - **Memory pressure**: Decrease `max_unflushed_gb` to reduce memory usage
 
+## Separate WAL Object Store
+
+By default the WAL is written to the same object store as everything else. You can point it at a separate, lower-latency store to reduce fsync latency. See [Separate WAL Store](/separate-wal) for details.
+
+```toml
+[wal]
+url = "file:///mnt/nvme/zerofs-wal"
+```
+
+The `[wal]` section supports its own `[wal.aws]`, `[wal.azure]`, and `[wal.gcp]` credential blocks, independent from the main storage credentials.
+
+<Note>
+Whether you use a separate WAL store is decided at filesystem creation time and cannot be changed later.
+</Note>
+
 ## Multiple Instances
 
 ZeroFS supports running multiple instances on the same storage backend: one read-write instance and multiple read-only instances.

--- a/documentation/src/app/separate-wal/page.mdx
+++ b/documentation/src/app/separate-wal/page.mdx
@@ -1,0 +1,42 @@
+export const metadata = {
+  title: 'Separate WAL Object Store',
+  description:
+    'Use a faster object store for WAL writes to reduce fsync latency.',
+}
+
+# Separate WAL Object Store
+
+Every `fsync` writes to the WAL, so fsync latency equals the latency of the WAL's backing store. You can point the WAL at a separate, lower-latency store to reduce this latency. {{ className: 'lead' }}
+
+## Overview
+
+By default the WAL goes to the same object store as everything else. If fsync latency matters for your workload, you can configure a separate WAL store for example local NVMe, S3 Express One Zone, or a nearby S3-compatible service.
+
+## Configuration
+
+Add a `[wal]` section to your configuration file:
+
+```toml
+[wal]
+url = "file:///mnt/nvme/zerofs-wal"
+```
+
+The `[wal]` section supports its own credential blocks (`[wal.aws]`, `[wal.azure]`, `[wal.gcp]`), independent from the main storage credentials:
+
+```toml
+[wal]
+url = "s3://my-wal-bucket/zerofs-wal"
+
+[wal.aws]
+access_key_id = "${WAL_AWS_KEY}"
+secret_access_key = "${WAL_AWS_SECRET}"
+endpoint = "https://s3-endpoint.example.com"
+```
+
+If no `[wal]` section is present, the WAL is written to the main object store.
+
+## Important Constraints
+
+Whether you use a separate WAL store is decided at filesystem creation time. The underlying storage engine records this in its manifest, so you cannot add or remove a separate WAL store on an existing filesystem.
+
+You can move the WAL to a different location by updating the `[wal]` URL and credentials, but you must manually migrate the WAL files from the old store to the new one before starting ZeroFS.

--- a/documentation/src/components/Navigation.tsx
+++ b/documentation/src/components/Navigation.tsx
@@ -244,6 +244,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'Configuration', href: '/configuration' },
       { title: 'Checkpoints', href: '/checkpoints' },
       { title: 'Standalone Compactor', href: '/standalone-compactor' },
+      { title: 'Separate WAL Store', href: '/separate-wal' },
       { title: 'Troubleshooting', href: '/troubleshooting' },
       { title: 'Advanced Use Cases', href: '/advanced-use-cases' },
     ],

--- a/zerofs/Cargo.lock
+++ b/zerofs/Cargo.lock
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.12.4"
-source = "git+https://github.com/Barre/arrow-rs-object-store?branch=feat%2Fs3-redis-conditional-put-0.12.4#b0f870f43aa77d62638b9d29bc72ec90f452c555"
+source = "git+https://github.com/Barre/arrow-rs-object-store?rev=01b0349f126c9eda8e7ad8767c7e4868debe3602#01b0349f126c9eda8e7ad8767c7e4868debe3602"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "zerofs"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/zerofs/Cargo.toml
+++ b/zerofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerofs"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 description = "A high-performance filesystem that makes S3 your primary storage with NFS, 9P, and NBD support"
 license = "AGPL-3.0"
@@ -77,7 +77,7 @@ chrono = "0.4"
 fail = { version = "0.5", features = ["failpoints"], optional = true }
 
 [patch.crates-io]
-object_store = { git = "https://github.com/Barre/arrow-rs-object-store", branch = "feat/s3-redis-conditional-put-0.12.4" }
+object_store = { git = "https://github.com/Barre/arrow-rs-object-store", rev = "01b0349f126c9eda8e7ad8767c7e4868debe3602" }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/zerofs/src/checkpoint_manager.rs
+++ b/zerofs/src/checkpoint_manager.rs
@@ -21,8 +21,17 @@ pub struct CheckpointManager {
 }
 
 impl CheckpointManager {
-    pub fn new(db_handle: SlateDbHandle, path: Path, object_store: Arc<dyn ObjectStore>) -> Self {
-        let admin = slatedb::admin::AdminBuilder::new(path, object_store).build();
+    pub fn new(
+        db_handle: SlateDbHandle,
+        path: Path,
+        object_store: Arc<dyn ObjectStore>,
+        wal_object_store: Option<Arc<dyn ObjectStore>>,
+    ) -> Self {
+        let mut admin_builder = slatedb::admin::AdminBuilder::new(path, object_store);
+        if let Some(wal_store) = wal_object_store {
+            admin_builder = admin_builder.with_wal_object_store(wal_store);
+        }
+        let admin = admin_builder.build();
         Self { db_handle, admin }
     }
 

--- a/zerofs/src/cli/debug.rs
+++ b/zerofs/src/cli/debug.rs
@@ -52,6 +52,13 @@ pub async fn list_keys(config_path: PathBuf) -> Result<()> {
     let block_transformer: Arc<dyn BlockTransformer> =
         ZeroFsBlockTransformer::new_arc(&encryption_key, settings.compression());
 
+    let wal_object_store: Option<Arc<dyn object_store::ObjectStore>> =
+        if let Some(wal_config) = &settings.wal {
+            Some(super::server::parse_wal_object_store(wal_config)?)
+        } else {
+            None
+        };
+
     let (slatedb, _, _) = super::server::build_slatedb(
         object_store,
         &cache_config,
@@ -60,6 +67,7 @@ pub async fn list_keys(config_path: PathBuf) -> Result<()> {
         settings.lsm,
         false, // don't disable compactor
         block_transformer,
+        wal_object_store,
     )
     .await?;
 


### PR DESCRIPTION
Allow configuring a dedicated object store for WAL writes via a [wal] config section, reducing fsync latency when pointed at faster storage (local NVMe, S3 Express, nearby S3-compatible).