### PR TITLE
Use system protoc if available

### DIFF
--- a/zerofs/Cargo.toml
+++ b/zerofs/Cargo.toml
@@ -23,9 +23,10 @@ lto = false
 codegen-units = 16
 
 [features]
-default = []
+default = ["vendored-protoc"]
 tokio-console = ["dep:console-subscriber"]
 failpoints = ["dep:fail"]
+vendored-protoc = ["dep:protobuf-src"]
 
 [dependencies]
 console-subscriber = { version = "0.5", optional = true }
@@ -81,7 +82,7 @@ object_store = { git = "https://github.com/Barre/arrow-rs-object-store", rev = "
 
 [build-dependencies]
 tonic-prost-build = "0.14"
-protobuf-src = "2"
+protobuf-src = { version = "2", optional = true }
 
 [dev-dependencies]
 tempfile = "3.21"

--- a/zerofs/build.rs
+++ b/zerofs/build.rs
@@ -1,9 +1,22 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo::rerun-if-changed=proto/admin.proto");
 
-    // SAFETY: Build scripts are single-threaded
-    unsafe {
-        std::env::set_var("PROTOC", protobuf_src::protoc());
+    // Use system protoc if available, otherwise build from source via protobuf-src
+    if std::env::var("PROTOC").is_err() && !has_system_protoc() {
+        #[cfg(feature = "vendored-protoc")]
+        {
+            // SAFETY: Build scripts are single-threaded
+            unsafe {
+                std::env::set_var("PROTOC", protobuf_src::protoc());
+            }
+        }
+        #[cfg(not(feature = "vendored-protoc"))]
+        {
+            panic!(
+                "no system protoc found and the 'vendored-protoc' feature is disabled. \
+                 Either install protobuf-compiler or enable the 'vendored-protoc' feature."
+            );
+        }
     }
 
     tonic_prost_build::configure()
@@ -11,4 +24,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_client(true)
         .compile_protos(&["proto/admin.proto"], &["proto/"])?;
     Ok(())
+}
+
+fn has_system_protoc() -> bool {
+    std::process::Command::new("protoc")
+        .arg("--version")
+        .output()
+        .is_ok()
 }


### PR DESCRIPTION
Prefer system protoc over building from source. The vendored-protoc feature (enabled by default) falls back to protobuf-src when no system protoc is found.

Packagers can build with --no-default-features to skip protobuf-src entirely.

Closes #353