### PR TITLE
Replace SlateDB CachedObjectStore with foyer-hybrid + in-memory prefetch wrapper

### DIFF
--- a/zerofs/.cargo/config.toml
+++ b/zerofs/.cargo/config.toml
@@ -1,8 +1,15 @@
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=x86-64-v3", "--cfg", "tokio_unstable"]
+rustflags = [
+    "-C", "target-cpu=x86-64-v3",
+    "--cfg", "tokio_unstable",
+    "--cfg", "io_uring_skip_arch_check",
+]
 
 [build]
-rustflags = ["--cfg", "tokio_unstable"]
+rustflags = [
+    "--cfg", "tokio_unstable",
+    "--cfg", "io_uring_skip_arch_check",
+]
 
 [env]
 JEMALLOC_SYS_WITH_MALLOC_CONF = "retain:true,dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true"

--- a/zerofs/Cargo.lock
+++ b/zerofs/Cargo.lock
@@ -25,7 +25,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -174,34 +173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,18 +197,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auto_enums"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65398a2893f41bce5c9259f6e1a4f03fbae40637c1bdc755b4f387f48c613b03"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "autocfg"
@@ -532,7 +491,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -688,6 +647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,16 +760,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -820,20 +780,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
@@ -842,7 +788,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -855,19 +801,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -975,17 +910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_utils"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,12 +966,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duration-str"
@@ -1127,13 +1045,14 @@ dependencies = [
 
 [[package]]
 name = "fail-parallel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5666e8ca4ec174d896fb742789c29b1bea9319dcfd623c41bececc0a60c4939d"
+checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.9.2",
+ "tokio",
 ]
 
 [[package]]
@@ -1245,18 +1164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,40 +1192,39 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642093b1a72c4a0ef89862484d669a353e732974781bb9c49a979526d1e30edc"
+checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
 dependencies = [
+ "anyhow",
  "equivalent",
  "foyer-common",
  "foyer-memory",
  "foyer-storage",
- "madsim-tokio",
+ "foyer-tokio",
+ "futures-util",
+ "mea",
  "mixtrics",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-common"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db9c0e4648b13e9216d785b308d43751ca975301aeb83e607ec630b6f956944"
+checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
 dependencies = [
+ "anyhow",
  "bincode",
  "bytes",
  "cfg-if",
- "itertools",
- "madsim-tokio",
+ "foyer-tokio",
  "mixtrics",
  "parking_lot",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "twox-hash",
 ]
 
@@ -1333,60 +1239,69 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040dc38acbfca8f1def26bbbd9e9199090884aabb15de99f7bf4060be66ff608"
+checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
 dependencies = [
- "arc-swap",
+ "anyhow",
  "bitflags 2.11.0",
  "cmsketch",
  "equivalent",
  "foyer-common",
  "foyer-intrusive-collections",
- "hashbrown 0.15.5",
+ "foyer-tokio",
+ "futures-util",
+ "hashbrown 0.16.1",
  "itertools",
- "madsim-tokio",
+ "mea",
  "mixtrics",
  "parking_lot",
+ "paste",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-storage"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a77ed888da490e997da6d6d62fcbce3f202ccf28be098c4ea595ca046fc4a9"
+checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
 dependencies = [
  "allocator-api2",
  "anyhow",
- "auto_enums",
  "bytes",
+ "core_affinity",
  "equivalent",
- "flume",
+ "fastant",
  "foyer-common",
  "foyer-memory",
+ "foyer-tokio",
  "fs4",
  "futures-core",
  "futures-util",
+ "hashbrown 0.16.1",
+ "io-uring",
  "itertools",
  "libc",
  "lz4",
- "madsim-tokio",
- "ordered_hash_map",
+ "mea",
  "parking_lot",
- "paste",
  "pin-project",
  "rand 0.9.2",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "foyer-tokio"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -1576,15 +1491,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1595,8 +1501,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1616,6 +1520,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1641,6 +1550,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1981,6 +1896,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2064,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,61 +2117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "madsim"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18351aac4194337d6ea9ffbd25b3d1540ecc0754142af1bff5ba7392d1f6f771"
-dependencies = [
- "ahash",
- "async-channel",
- "async-stream",
- "async-task",
- "bincode",
- "bytes",
- "downcast-rs",
- "errno",
- "futures-util",
- "lazy_static",
- "libc",
- "madsim-macros",
- "naive-timer",
- "panic-message",
- "rand 0.8.5",
- "rand_xoshiro 0.6.0",
- "rustversion",
- "serde",
- "spin",
- "tokio",
- "tokio-util",
- "toml 0.9.12+spec-1.1.0",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "madsim-macros"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d248e97b1a48826a12c3828d921e8548e714394bf17274dd0a93910dc946e1"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "madsim-tokio"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3eb2acc57c82d21d699119b859e2df70a91dbdb84734885a1e72be83bdecb5"
-dependencies = [
- "madsim",
- "spin",
- "tokio",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2139,15 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6747f54621d156e1b47eb6b25f39a941b9fc347f98f67d25d8881ff99e8ed832"
+dependencies = [
+ "slab",
 ]
 
 [[package]]
@@ -2318,7 +2207,7 @@ dependencies = [
  "metrics",
  "quanta",
  "rand 0.9.2",
- "rand_xoshiro 0.7.0",
+ "rand_xoshiro",
  "sketches-ddsketch",
 ]
 
@@ -2371,21 +2260,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "naive-timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "nix"
@@ -2471,6 +2345,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2579,15 +2463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered_hash_map"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e5f22bf6dd04abd854a8874247813a8fa2c8c1260eba6fbb150270ce7c176"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "ouroboros"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,12 +2485,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "panic-message"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
 
 [[package]]
 name = "parking"
@@ -3168,15 +3037,6 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
@@ -3210,7 +3070,7 @@ dependencies = [
  "indoc",
  "itertools",
  "kasuari",
- "lru",
+ "lru 0.16.3",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -3816,15 +3676,13 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slatedb"
 version = "0.12.0"
-source = "git+https://github.com/Barre/slatedb.git?rev=d14e9c177244ce2820e7c2fc7e1d1f63c1758577#d14e9c177244ce2820e7c2fc7e1d1f63c1758577"
+source = "git+https://github.com/Barre/slatedb.git?rev=650ef0716ba2209efbf2c5483bf4f843f1494b15#650ef0716ba2209efbf2c5483bf4f843f1494b15"
 dependencies = [
- "anyhow",
  "async-channel",
  "async-trait",
  "atomic",
  "backon",
  "bitflags 2.11.0",
- "bytemuck",
  "bytes",
  "chrono",
  "crc32fast",
@@ -3837,12 +3695,13 @@ dependencies = [
  "foyer",
  "futures",
  "log",
+ "lru 0.18.0",
  "object_store",
  "once_cell",
  "ouroboros",
  "parking_lot",
  "rand 0.9.2",
- "rand_xoshiro 0.7.0",
+ "rand_xoshiro",
  "serde",
  "serde_json",
  "siphasher",
@@ -3863,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "slatedb-common"
 version = "0.12.0"
-source = "git+https://github.com/Barre/slatedb.git?rev=d14e9c177244ce2820e7c2fc7e1d1f63c1758577#d14e9c177244ce2820e7c2fc7e1d1f63c1758577"
+source = "git+https://github.com/Barre/slatedb.git?rev=650ef0716ba2209efbf2c5483bf4f843f1494b15#650ef0716ba2209efbf2c5483bf4f843f1494b15"
 dependencies = [
  "chrono",
  "log",
@@ -3874,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "slatedb-txn-obj"
 version = "0.12.0"
-source = "git+https://github.com/Barre/slatedb.git?rev=d14e9c177244ce2820e7c2fc7e1d1f63c1758577#d14e9c177244ce2820e7c2fc7e1d1f63c1758577"
+source = "git+https://github.com/Barre/slatedb.git?rev=650ef0716ba2209efbf2c5483bf4f843f1494b15#650ef0716ba2209efbf2c5483bf4f843f1494b15"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3909,15 +3768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3928,12 +3778,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -5026,7 +4870,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float",
- "strsim 0.11.1",
+ "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
@@ -5607,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "zerofs"
-version = "1.0.14"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5626,6 +5470,7 @@ dependencies = [
  "deku",
  "fail",
  "fastant",
+ "foyer",
  "futures",
  "hkdf",
  "http-body-util",

--- a/zerofs/Cargo.toml
+++ b/zerofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerofs"
-version = "1.0.14"
+version = "1.1.0"
 edition = "2024"
 description = "A high-performance filesystem that makes S3 your primary storage with NFS, 9P, and NBD support"
 license = "AGPL-3.0"
@@ -40,10 +40,10 @@ webui = ["dep:rust-embed", "dep:axum", "dep:tonic-web", "dep:tower-http"]
 [dependencies]
 reqwest = { version = "0.12", default-features = false }
 console-subscriber = { version = "0.5", optional = true }
-slatedb = { git = "https://github.com/Barre/slatedb.git", rev = "d14e9c177244ce2820e7c2fc7e1d1f63c1758577", features = [
+slatedb = { git = "https://github.com/Barre/slatedb.git", rev = "650ef0716ba2209efbf2c5483bf4f843f1494b15", features = [
     "wal_disable",
 ] }
-slatedb-common = { git = "https://github.com/Barre/slatedb.git", rev = "d14e9c177244ce2820e7c2fc7e1d1f63c1758577" }
+slatedb-common = { git = "https://github.com/Barre/slatedb.git", rev = "650ef0716ba2209efbf2c5483bf4f843f1494b15" }
 fastant = "0.1.11"
 zerofs_nfsserve = "0.19.1"
 tikv-jemallocator = { version = "0.6", features = ["background_threads"] }
@@ -98,6 +98,7 @@ rust-embed = { version = "8", optional = true }
 axum = { version = "0.8", features = ["ws"], optional = true }
 tonic-web = { version = "0.13", optional = true }
 tower-http = { version = "0.6", features = ["cors"], optional = true }
+foyer = "0.22"
 
 [patch.crates-io]
 object_store = { git = "https://github.com/Barre/arrow-rs-object-store", rev = "01b0349f126c9eda8e7ad8767c7e4868debe3602" }

--- a/zerofs/src/cli/compactor.rs
+++ b/zerofs/src/cli/compactor.rs
@@ -1,6 +1,7 @@
 use crate::block_transformer::ZeroFsBlockTransformer;
 use crate::config::Settings;
 use crate::key_management;
+use crate::object_store_prefetch::PrefetchingObjectStore;
 use crate::parse_object_store::parse_url_opts;
 use anyhow::{Context, Result};
 use slatedb::BlockTransformer;
@@ -63,6 +64,22 @@ pub async fn run_compactor(config_path: PathBuf) -> Result<()> {
         max_fetch_tasks: 8,
         ..Default::default()
     };
+
+    let foyer_handle = {
+        let rt = tokio::runtime::Runtime::new().expect("failed to build foyer runtime");
+        let handle = rt.handle().clone();
+        std::thread::spawn(move || {
+            rt.block_on(async { std::future::pending::<()>().await });
+        });
+        handle
+    };
+    let total_disk_bytes = (settings.cache.disk_size_gb * 1_000_000_000.0) as usize;
+    let (parts_disk_bytes, _) = super::server::split_disk_budget(total_disk_bytes);
+    let parts_cache =
+        super::server::build_parts_hybrid(&settings.cache.dir, parts_disk_bytes, &foyer_handle)
+            .await?;
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(PrefetchingObjectStore::new(object_store, parts_cache));
 
     let compactor = Arc::new(
         CompactorBuilder::new(db_path, object_store)

--- a/zerofs/src/cli/server.rs
+++ b/zerofs/src/cli/server.rs
@@ -10,14 +10,19 @@ use crate::fs::types::SetAttributes;
 use crate::fs::{CacheConfig, GarbageCollector, ZeroFS};
 use crate::key_management;
 use crate::nbd::NBDServer;
+use crate::object_store_prefetch::PrefetchingObjectStore;
 use crate::parse_object_store::parse_url_opts;
 use crate::task::spawn_named;
 use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
-use slatedb::admin::AdminBuilder;
-use slatedb::config::{
-    GarbageCollectorDirectoryOptions, GarbageCollectorOptions, ObjectStoreCacheOptions,
+use foyer::{
+    BlockEngineConfig, DeviceBuilder, FsDeviceBuilder, HybridCacheBuilder, PsyncIoEngineConfig,
+    Spawner,
 };
+use slatedb::admin::AdminBuilder;
+use slatedb::config::GarbageCollectorDirectoryOptions;
+use slatedb::config::GarbageCollectorOptions;
+use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
 use slatedb::object_store::path::Path;
 use slatedb::{BlockTransformer, CompactorBuilder, DbBuilder, DbReader};
 use slatedb_common::metrics::DefaultMetricsRecorder;
@@ -330,6 +335,58 @@ fn start_periodic_flush(
     })
 }
 
+pub(crate) async fn build_parts_hybrid(
+    cache_root: &std::path::Path,
+    disk_bytes: usize,
+    foyer_handle: &tokio::runtime::Handle,
+) -> Result<foyer::HybridCache<crate::object_store_prefetch::PartKey, bytes::Bytes>> {
+    use crate::object_store_prefetch::PartKey;
+    use bytes::Bytes;
+
+    const PARTS_MEMORY_BYTES: usize = 128 * 1024 * 1024;
+
+    let parts_root = cache_root.join("parts_cache");
+    tokio::fs::create_dir_all(&parts_root)
+        .await
+        .with_context(|| format!("creating parts cache dir at {}", parts_root.display()))?;
+    HybridCacheBuilder::new()
+        .with_name("zerofs-object-prefetch-parts")
+        .memory(PARTS_MEMORY_BYTES)
+        .with_weighter(|_: &PartKey, v: &Bytes| v.len())
+        .storage()
+        .with_spawner(Spawner::from(foyer_handle.clone()))
+        .with_io_engine_config(PsyncIoEngineConfig::new())
+        .with_engine_config(
+            BlockEngineConfig::new(
+                FsDeviceBuilder::new(&parts_root)
+                    .with_capacity(disk_bytes)
+                    .build()
+                    .map_err(|e| anyhow::anyhow!("parts foyer device build failed: {e}"))?,
+            )
+            .with_block_size(64 * 1024 * 1024),
+        )
+        .build()
+        .await
+        .map_err(|e| anyhow::anyhow!("parts foyer hybrid build failed: {e}"))
+}
+
+/// Compute (parts_disk_bytes, decoded_blocks_disk_bytes) from a total disk
+/// budget. Parts get 10% of the budget, clamped to [256 MiB, 10 GiB]; the
+/// decoded-blocks hybrid takes the rest. Floors at 256 MiB so neither side
+/// collapses to zero on tiny configurations.
+pub(crate) fn split_disk_budget(total_disk_bytes: usize) -> (usize, usize) {
+    const MIN_PARTS_BYTES: usize = 1024 * 1024 * 1024;
+    const MAX_PARTS_BYTES: usize = 10_usize
+        .saturating_mul(1024)
+        .saturating_mul(1024)
+        .saturating_mul(1024);
+
+    let parts = (total_disk_bytes / 10).clamp(MIN_PARTS_BYTES, MAX_PARTS_BYTES);
+    let parts = parts.min(total_disk_bytes.saturating_sub(MIN_PARTS_BYTES));
+    let decoded = total_disk_bytes.saturating_sub(parts).max(MIN_PARTS_BYTES);
+    (parts, decoded)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn build_slatedb(
     object_store: Arc<dyn object_store::ObjectStore>,
@@ -348,17 +405,17 @@ pub async fn build_slatedb(
     let total_disk_cache_gb = cache_config.max_cache_size_gb;
     let total_memory_cache_gb = cache_config.memory_cache_size_gb.unwrap_or(0.25);
 
-    info!(
-        "Cache allocation - Disk: {:.2}GB, Memory: {:.2}GB",
-        total_disk_cache_gb, total_memory_cache_gb,
-    );
-
-    let slatedb_object_cache_bytes = (total_disk_cache_gb * 1_000_000_000.0) as usize;
-    let slatedb_memory_cache_bytes = (total_memory_cache_gb * 1_000_000_000.0) as u64;
+    let total_disk_bytes = (total_disk_cache_gb * 1_000_000_000.0) as usize;
+    let (parts_disk_bytes, hybrid_disk_bytes) = split_disk_budget(total_disk_bytes);
+    let hybrid_memory_bytes = (total_memory_cache_gb * 1_000_000_000.0) as usize;
 
     info!(
-        "SlateDB in-memory block cache: {} MB",
-        slatedb_memory_cache_bytes / 1_000_000
+        "Cache allocation - Disk: {:.2}GB total ({} MB decoded-blocks + {} MB raw-parts), \
+         Memory: {:.2}GB",
+        total_disk_cache_gb,
+        hybrid_disk_bytes / 1_000_000,
+        parts_disk_bytes / 1_000_000,
+        total_memory_cache_gb,
     );
 
     let l0_max_ssts = lsm_config
@@ -379,14 +436,7 @@ pub async fn build_slatedb(
         wal_enabled,
         l0_max_ssts,
         l0_sst_size_bytes: 128 * 1024 * 1024,
-        filter_bits_per_key: 10,
         compactor_options: None,
-        object_store_cache_options: ObjectStoreCacheOptions {
-            root_folder: Some(cache_config.root_folder.clone()),
-            max_cache_size_bytes: Some(slatedb_object_cache_bytes),
-            cache_puts: true,
-            ..Default::default()
-        },
         flush_interval: Some(std::time::Duration::from_secs(30)),
         max_unflushed_bytes,
         compression_codec: None, // Disable compression as we handle it in encryption layer
@@ -408,16 +458,55 @@ pub async fn build_slatedb(
                 interval: Some(Duration::from_mins(1)),
                 min_age: Duration::from_mins(1),
             }),
+            detach_options: None,
         }),
         ..Default::default()
     };
 
-    let cache = Arc::new(slatedb::db_cache::foyer::FoyerCache::new_with_opts(
-        slatedb::db_cache::foyer::FoyerCacheOptions {
-            max_capacity: slatedb_memory_cache_bytes,
-            ..Default::default()
-        },
-    ));
+    let foyer_handle = {
+        let rt = Runtime::new().expect("failed to build foyer runtime");
+        let handle = rt.handle().clone();
+        std::thread::spawn(move || {
+            rt.block_on(async { std::future::pending::<()>().await });
+        });
+        handle
+    };
+
+    let hybrid_cache_root = cache_config.root_folder.join("hybrid_cache");
+    tokio::fs::create_dir_all(&hybrid_cache_root)
+        .await
+        .with_context(|| {
+            format!(
+                "creating foyer hybrid cache dir at {}",
+                hybrid_cache_root.display()
+            )
+        })?;
+
+    let hybrid = HybridCacheBuilder::new()
+        .with_name("zerofs-slatedb-hybrid")
+        .memory(hybrid_memory_bytes)
+        .with_weighter(|_, v: &slatedb::db_cache::CachedEntry| v.size())
+        .storage()
+        .with_spawner(Spawner::from(foyer_handle.clone()))
+        .with_io_engine_config(PsyncIoEngineConfig::new())
+        .with_engine_config(
+            BlockEngineConfig::new(
+                FsDeviceBuilder::new(&hybrid_cache_root)
+                    .with_capacity(hybrid_disk_bytes)
+                    .build()
+                    .map_err(|e| anyhow::anyhow!("foyer device build failed: {e}"))?,
+            )
+            .with_block_size(64 * 1024 * 1024),
+        )
+        .build()
+        .await
+        .map_err(|e| anyhow::anyhow!("foyer hybrid build failed: {e}"))?;
+    let cache = Arc::new(FoyerHybridCache::new_with_cache(hybrid));
+
+    let parts_cache =
+        build_parts_hybrid(&cache_config.root_folder, parts_disk_bytes, &foyer_handle).await?;
+    let object_store: Arc<dyn object_store::ObjectStore> =
+        Arc::new(PrefetchingObjectStore::new(object_store, parts_cache));
 
     let db_path = Path::from(db_path);
 

--- a/zerofs/src/lib.rs
+++ b/zerofs/src/lib.rs
@@ -2,6 +2,7 @@ pub mod block_transformer;
 pub mod config;
 pub mod db;
 pub mod fs;
+pub mod object_store_prefetch;
 pub mod task;
 
 #[cfg(feature = "failpoints")]

--- a/zerofs/src/main.rs
+++ b/zerofs/src/main.rs
@@ -13,6 +13,7 @@ mod key_management;
 mod nbd;
 mod nfs;
 mod ninep;
+mod object_store_prefetch;
 mod parse_object_store;
 mod prometheus;
 mod rpc;

--- a/zerofs/src/object_store_prefetch.rs
+++ b/zerofs/src/object_store_prefetch.rs
@@ -1,0 +1,670 @@
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use foyer::{Cache, HybridCache};
+use futures::StreamExt;
+use futures::future::BoxFuture;
+use futures::stream::{self, BoxStream};
+use object_store::path::Path;
+use object_store::{
+    Attributes, GetOptions, GetRange, GetResult, GetResultPayload, ListResult, MultipartUpload,
+    ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Display, Formatter};
+use std::ops::Range;
+use std::sync::Arc;
+
+pub const DEFAULT_PART_SIZE_BYTES: usize = 2 * 1024 * 1024;
+const HEADS_CAPACITY_ENTRIES: usize = 16 * 1024;
+
+type PartId = usize;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PartKey {
+    location: String,
+    part_id: PartId,
+}
+
+impl PartKey {
+    fn new(location: &Path, part_id: PartId) -> Self {
+        Self {
+            location: location.as_ref().to_string(),
+            part_id,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CachedHead {
+    meta: ObjectMeta,
+    attributes: Attributes,
+}
+
+pub struct PrefetchingObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    part_size_bytes: usize,
+    parts: HybridCache<PartKey, Bytes>,
+    heads: Cache<Path, Arc<CachedHead>>,
+}
+
+impl PrefetchingObjectStore {
+    pub fn new(inner: Arc<dyn ObjectStore>, parts: HybridCache<PartKey, Bytes>) -> Self {
+        Self::with_options(inner, parts, DEFAULT_PART_SIZE_BYTES)
+    }
+
+    pub fn with_options(
+        inner: Arc<dyn ObjectStore>,
+        parts: HybridCache<PartKey, Bytes>,
+        part_size_bytes: usize,
+    ) -> Self {
+        assert!(
+            part_size_bytes > 0 && part_size_bytes.is_multiple_of(1024),
+            "part_size_bytes must be a positive multiple of 1024"
+        );
+        let heads = foyer::CacheBuilder::new(HEADS_CAPACITY_ENTRIES)
+            .with_name("zerofs-object-prefetch-heads")
+            .build();
+        Self {
+            inner,
+            part_size_bytes,
+            parts,
+            heads,
+        }
+    }
+
+    fn save_head(&self, location: &Path, meta: &ObjectMeta, attrs: &Attributes) {
+        self.heads.insert(
+            location.clone(),
+            Arc::new(CachedHead {
+                meta: meta.clone(),
+                attributes: attrs.clone(),
+            }),
+        );
+    }
+
+    fn read_head(&self, location: &Path) -> Option<(ObjectMeta, Attributes)> {
+        self.heads
+            .get(location)
+            .map(|entry| (entry.value().meta.clone(), entry.value().attributes.clone()))
+    }
+
+    fn save_part(&self, location: &Path, part_id: PartId, bytes: Bytes) {
+        self.parts.insert(PartKey::new(location, part_id), bytes);
+    }
+
+    #[cfg(test)]
+    async fn cached_part(&self, location: &Path, part_id: PartId) -> Option<Bytes> {
+        self.parts
+            .get(&PartKey::new(location, part_id))
+            .await
+            .ok()
+            .flatten()
+            .map(|entry| entry.value().clone())
+    }
+
+    fn invalidate(&self, location: &Path) {
+        self.heads.remove(location);
+    }
+
+    async fn cached_head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        if let Some((meta, _)) = self.read_head(location) {
+            return Ok(meta);
+        }
+        let result = self
+            .inner
+            .get_opts(
+                location,
+                GetOptions {
+                    range: None,
+                    head: true,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let meta = result.meta.clone();
+        let _ = self.save_get_result(location, result).await;
+        Ok(meta)
+    }
+
+    async fn cached_get_opts(
+        &self,
+        location: &Path,
+        opts: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        if opts.if_match.is_some()
+            || opts.if_none_match.is_some()
+            || opts.if_modified_since.is_some()
+            || opts.if_unmodified_since.is_some()
+            || opts.version.is_some()
+            || opts.head
+        {
+            return self.inner.get_opts(location, opts).await;
+        }
+
+        let (meta, attributes) = self.maybe_prefetch_range(location, opts.clone()).await?;
+        let range = self.canonicalize_range(opts.range.clone(), meta.size)?;
+        let parts = self.split_range_into_parts(range.clone());
+
+        let futures = parts
+            .into_iter()
+            .map(|(part_id, range_in_part)| {
+                self.read_part(location.clone(), part_id, range_in_part)
+            })
+            .collect::<Vec<_>>();
+        let result_stream = stream::iter(futures).then(|fut| fut).boxed();
+
+        Ok(GetResult {
+            meta,
+            range,
+            attributes,
+            payload: GetResultPayload::Stream(result_stream),
+        })
+    }
+
+    async fn maybe_prefetch_range(
+        &self,
+        location: &Path,
+        mut opts: GetOptions,
+    ) -> object_store::Result<(ObjectMeta, Attributes)> {
+        if let Some((meta, attrs)) = self.read_head(location) {
+            return Ok((meta, attrs));
+        }
+
+        if let Some(range) = &opts.range {
+            opts.range = Some(self.align_get_range(range));
+        }
+
+        let get_result = self.inner.get_opts(location, opts).await?;
+        let meta = get_result.meta.clone();
+        let attrs = get_result.attributes.clone();
+        let _ = self.save_get_result(location, get_result).await;
+        Ok((meta, attrs))
+    }
+
+    async fn save_get_result(
+        &self,
+        location: &Path,
+        result: GetResult,
+    ) -> object_store::Result<()> {
+        self.save_head(location, &result.meta, &result.attributes);
+
+        let part_size = self.part_size_bytes as u64;
+        let aligned_start = result.range.start.is_multiple_of(part_size);
+        let aligned_end =
+            result.range.end.is_multiple_of(part_size) || result.range.end == result.meta.size;
+        if !(aligned_start && aligned_end) {
+            return Ok(());
+        }
+
+        let start_part: PartId = (result.range.start / part_size)
+            .try_into()
+            .expect("part number exceeds usize");
+
+        let stream = result.into_stream();
+        self.save_parts_stream(location, stream, start_part).await
+    }
+
+    async fn save_parts_stream<S>(
+        &self,
+        location: &Path,
+        mut stream: S,
+        start_part_number: PartId,
+    ) -> object_store::Result<()>
+    where
+        S: stream::Stream<Item = Result<Bytes, object_store::Error>> + Unpin,
+    {
+        let mut buffer = BytesMut::new();
+        let mut part_number = start_part_number;
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            buffer.extend_from_slice(&chunk);
+            while buffer.len() >= self.part_size_bytes {
+                let to_write = buffer.split_to(self.part_size_bytes);
+                self.save_part(location, part_number, to_write.freeze());
+                part_number += 1;
+            }
+        }
+
+        if !buffer.is_empty() {
+            self.save_part(location, part_number, buffer.freeze());
+        }
+        Ok(())
+    }
+
+    fn split_range_into_parts(&self, range: Range<u64>) -> Vec<(PartId, Range<usize>)> {
+        let part_size_u64 = self.part_size_bytes as u64;
+        let aligned = self.align_range(&range, self.part_size_bytes);
+        let start_part = aligned.start / part_size_u64;
+        let end_part = aligned.end / part_size_u64;
+        let mut parts: Vec<_> = (start_part..end_part)
+            .map(|part_id| {
+                (
+                    usize::try_from(part_id).expect("part id exceeds usize"),
+                    Range {
+                        start: 0,
+                        end: self.part_size_bytes,
+                    },
+                )
+            })
+            .collect();
+        if parts.is_empty() {
+            return vec![];
+        }
+        if let Some(first) = parts.first_mut() {
+            first.1.start = usize::try_from(range.start % part_size_u64)
+                .expect("part_size too large for usize");
+        }
+        if let Some(last) = parts.last_mut()
+            && !range.end.is_multiple_of(part_size_u64)
+        {
+            last.1.end =
+                usize::try_from(range.end % part_size_u64).expect("part_size too large for usize");
+        }
+        parts
+    }
+
+    fn read_part(
+        &self,
+        location: Path,
+        part_id: PartId,
+        range_in_part: Range<usize>,
+    ) -> BoxFuture<'static, object_store::Result<Bytes>> {
+        let inner = self.inner.clone();
+        let part_size_bytes = self.part_size_bytes;
+        let parts = self.parts.clone();
+        let heads = self.heads.clone();
+        Box::pin(async move {
+            let key = PartKey::new(&location, part_id);
+            if let Ok(Some(entry)) = parts.get(&key).await {
+                let bytes = entry.value().clone();
+                if range_in_part.end <= bytes.len() {
+                    return Ok(bytes.slice(range_in_part));
+                }
+                parts.remove(&key);
+            }
+
+            let part_range = Range {
+                start: (part_id * part_size_bytes) as u64,
+                end: ((part_id + 1) * part_size_bytes) as u64,
+            };
+            let get_result = inner
+                .get_opts(
+                    &location,
+                    GetOptions {
+                        range: Some(GetRange::Bounded(part_range)),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+            let meta = get_result.meta.clone();
+            let attrs = get_result.attributes.clone();
+            let bytes = get_result.bytes().await?;
+
+            heads.insert(
+                location.clone(),
+                Arc::new(CachedHead {
+                    meta,
+                    attributes: attrs,
+                }),
+            );
+            parts.insert(key, bytes.clone());
+
+            let end = range_in_part.end.min(bytes.len());
+            let start = range_in_part.start.min(end);
+            Ok(bytes.slice(start..end))
+        })
+    }
+
+    fn canonicalize_range(
+        &self,
+        range: Option<GetRange>,
+        object_size: u64,
+    ) -> object_store::Result<Range<u64>> {
+        let (start, end) = match range {
+            None => (0, object_size),
+            Some(GetRange::Bounded(r)) => {
+                if r.start >= object_size {
+                    return Err(object_store::Error::Generic {
+                        store: "PrefetchingObjectStore",
+                        source: format!("range start {} >= size {}", r.start, object_size).into(),
+                    });
+                }
+                if r.start >= r.end {
+                    return Err(object_store::Error::Generic {
+                        store: "PrefetchingObjectStore",
+                        source: format!("inconsistent range {}..{}", r.start, r.end).into(),
+                    });
+                }
+                (r.start, r.end.min(object_size))
+            }
+            Some(GetRange::Offset(o)) => {
+                if o >= object_size {
+                    return Err(object_store::Error::Generic {
+                        store: "PrefetchingObjectStore",
+                        source: format!("offset {} >= size {}", o, object_size).into(),
+                    });
+                }
+                (o, object_size)
+            }
+            Some(GetRange::Suffix(s)) => (object_size.saturating_sub(s), object_size),
+        };
+        Ok(Range { start, end })
+    }
+
+    fn align_get_range(&self, range: &GetRange) -> GetRange {
+        match range {
+            GetRange::Bounded(r) => GetRange::Bounded(self.align_range(r, self.part_size_bytes)),
+            GetRange::Suffix(s) => {
+                GetRange::Suffix(self.align_range(&(0..*s), self.part_size_bytes).end)
+            }
+            GetRange::Offset(o) => GetRange::Offset(*o - *o % self.part_size_bytes as u64),
+        }
+    }
+
+    fn align_range(&self, range: &Range<u64>, alignment: usize) -> Range<u64> {
+        let alignment = alignment as u64;
+        Range {
+            start: range.start - range.start % alignment,
+            end: range.end.div_ceil(alignment) * alignment,
+        }
+    }
+}
+
+impl Debug for PrefetchingObjectStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrefetchingObjectStore")
+            .field("inner", &self.inner)
+            .field("part_size_bytes", &self.part_size_bytes)
+            .finish()
+    }
+}
+
+impl Display for PrefetchingObjectStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "PrefetchingObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for PrefetchingObjectStore {
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.cached_get_opts(location, options).await
+    }
+
+    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        self.cached_head(location).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        let result = self.inner.put_opts(location, payload, opts).await?;
+        self.invalidate(location);
+        Ok(result)
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.invalidate(location);
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.invalidate(location);
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        let result = self.inner.delete(location).await;
+        self.invalidate(location);
+        result
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let result = self.inner.copy(from, to).await;
+        self.invalidate(to);
+        result
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let result = self.inner.rename(from, to).await;
+        self.invalidate(from);
+        self.invalidate(to);
+        result
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let result = self.inner.copy_if_not_exists(from, to).await;
+        if result.is_ok() {
+            self.invalidate(to);
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foyer::{BlockEngineConfig, FsDeviceBuilder, HybridCacheBuilder, PsyncIoEngineConfig};
+    use object_store::memory::InMemory;
+    use tempfile::TempDir;
+
+    async fn make_store(
+        part_size: usize,
+        memory_capacity: usize,
+        disk_capacity: usize,
+    ) -> (PrefetchingObjectStore, Arc<InMemory>, TempDir) {
+        let inner = Arc::new(InMemory::new());
+        let dir = tempfile::tempdir().unwrap();
+        let parts = HybridCacheBuilder::new()
+            .with_name("test-parts")
+            .memory(memory_capacity)
+            .with_weighter(|_: &PartKey, v: &Bytes| v.len())
+            .storage()
+            .with_io_engine_config(PsyncIoEngineConfig::new())
+            .with_engine_config(
+                BlockEngineConfig::new(
+                    foyer::DeviceBuilder::build(
+                        FsDeviceBuilder::new(dir.path()).with_capacity(disk_capacity),
+                    )
+                    .unwrap(),
+                )
+                .with_block_size(16 * 1024 * 1024),
+            )
+            .build()
+            .await
+            .unwrap();
+        let store = PrefetchingObjectStore::with_options(inner.clone(), parts, part_size);
+        (store, inner, dir)
+    }
+
+    const MEM: usize = 4 * 1024 * 1024;
+    const DISK: usize = 64 * 1024 * 1024;
+
+    #[tokio::test]
+    async fn small_read_caches_full_part() {
+        let (store, inner, _dir) = make_store(1024, MEM, DISK).await;
+        let path = Path::from("obj");
+        let body = vec![7u8; 4096];
+        inner.put(&path, body.clone().into()).await.unwrap();
+
+        let r1 = store
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some(GetRange::Bounded(10..20)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(r1.range, 10..20);
+        assert_eq!(&r1.bytes().await.unwrap()[..], &body[10..20]);
+
+        let r2 = store
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some(GetRange::Bounded(100..200)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(&r2.bytes().await.unwrap()[..], &body[100..200]);
+    }
+
+    #[tokio::test]
+    async fn full_object_read_populates_all_parts() {
+        let (store, inner, _dir) = make_store(1024, MEM, DISK).await;
+        let path = Path::from("obj");
+        let body: Vec<u8> = (0..8192u32).map(|i| (i % 251) as u8).collect();
+        inner.put(&path, body.clone().into()).await.unwrap();
+
+        let r = store.get_opts(&path, GetOptions::default()).await.unwrap();
+        assert_eq!(&r.bytes().await.unwrap()[..], &body[..]);
+
+        for part_id in 0..8 {
+            assert!(
+                store.cached_part(&path, part_id).await.is_some(),
+                "part {part_id} not cached"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn partial_cache_then_range_fetches_only_misses() {
+        let (store, inner, _dir) = make_store(1024, MEM, DISK).await;
+        let path = Path::from("obj");
+        let body = vec![3u8; 4096];
+        inner.put(&path, body.clone().into()).await.unwrap();
+
+        let _ = store
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some(GetRange::Bounded(0..1024)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let r = store.get_opts(&path, GetOptions::default()).await.unwrap();
+        assert_eq!(&r.bytes().await.unwrap()[..], &body[..]);
+        for part_id in 0..4 {
+            assert!(store.cached_part(&path, part_id).await.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn put_invalidates_head() {
+        let (store, _inner, _dir) = make_store(1024, MEM, DISK).await;
+        let path = Path::from("obj");
+        store.put(&path, vec![1u8; 100].into()).await.unwrap();
+        let _ = store.head(&path).await.unwrap();
+        store.put(&path, vec![2u8; 200].into()).await.unwrap();
+        let meta = store.head(&path).await.unwrap();
+        assert_eq!(meta.size, 200);
+        let r = store
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some(GetRange::Bounded(0..200)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(&r.bytes().await.unwrap()[..], &vec![2u8; 200][..]);
+    }
+
+    #[tokio::test]
+    async fn suffix_range() {
+        let (store, _inner, _dir) = make_store(1024, MEM, DISK).await;
+        let path = Path::from("obj");
+        let body = vec![5u8; 10_000];
+        store.put(&path, body.clone().into()).await.unwrap();
+        let r = store
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some(GetRange::Suffix(100)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let got = r.bytes().await.unwrap();
+        assert_eq!(got.len(), 100);
+        assert_eq!(&got[..], &body[body.len() - 100..]);
+    }
+
+    #[tokio::test]
+    async fn offset_range() {
+        let (store, _inner, _dir) = make_store(1024, MEM, DISK).await;
+        let path = Path::from("obj");
+        let body: Vec<u8> = (0..5000u32).map(|i| (i % 251) as u8).collect();
+        store.put(&path, body.clone().into()).await.unwrap();
+        let r = store
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some(GetRange::Offset(2500)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(&r.bytes().await.unwrap()[..], &body[2500..]);
+    }
+
+    #[tokio::test]
+    async fn conditional_get_bypasses_cache() {
+        let (store, inner, _dir) = make_store(1024, MEM, DISK).await;
+        let path = Path::from("obj");
+        inner.put(&path, vec![9u8; 100].into()).await.unwrap();
+        let r = store
+            .get_opts(
+                &path,
+                GetOptions {
+                    if_match: Some("never-matches".into()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        let _ = r;
+    }
+}


### PR DESCRIPTION
Move persistent caching to foyer-hybrid for decoded blocks, port SlateDB's prefetch logic into a foyer-backed PrefetchingObjectStore for raw parts, and isolate foyer's background work on a dedicated tokio runtime. Disk budget splits 10/90 between the two layers (parts capped at 10 GiB).