### PR TITLE
Skip empty WriteBatch commits to fix fatal exit on sub-chunk trim of a sparse file

### DIFF
--- a/zerofs/src/db.rs
+++ b/zerofs/src/db.rs
@@ -73,6 +73,10 @@ impl Transaction {
         self.ops.push(TxOp::Delete(key.clone()));
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+
     /// Replay this transaction's ops into `target`. SlateDB's `WriteBatch`
     /// already dedupes per key, so calling this on multiple transactions
     /// produces one merged batch with last-write-wins per key.

--- a/zerofs/src/fs/write_coordinator.rs
+++ b/zerofs/src/fs/write_coordinator.rs
@@ -77,7 +77,9 @@ async fn worker_loop(
 
         let mut merged = WriteBatch::new();
         let mut replies = Vec::with_capacity(batch.len());
+        let mut any_ops = false;
         for (txn, reply) in batch {
+            any_ops |= !txn.is_empty();
             txn.apply_to(&mut merged);
             replies.push(reply);
         }
@@ -92,23 +94,31 @@ async fn worker_loop(
                 KeyCodec::encode_counter(current),
             );
             last_emitted_counter = current;
+            any_ops = true;
         }
 
-        let mut result = db
-            .write_with_options(
+        // SlateDB rejects empty WriteBatches. A batch can be empty when every
+        // queued txn was a no-op (e.g. a sub-chunk trim against a fully sparse
+        // region produces no chunk writes) and no inode was allocated. Reply
+        // Ok without touching the db; there's nothing to make durable either.
+        let mut result = if any_ops {
+            db.write_with_options(
                 merged,
                 &WriteOptions {
                     await_durable: false,
                 },
             )
             .await
-            .map_err(|_| FsError::IoError);
+            .map_err(|_| FsError::IoError)
+        } else {
+            Ok(())
+        };
 
         // In sync_writes mode, force a flush after the batch is committed so
         // every caller in the batch only sees Ok once their data is durable in
         // object storage. FlushCoordinator coalesces concurrent flush requests
         // into a single db.flush()
-        if sync_writes && result.is_ok() {
+        if sync_writes && result.is_ok() && any_ops {
             result = flush_coordinator.flush().await;
         }
 
@@ -192,6 +202,20 @@ mod tests {
                 .unwrap();
             assert!(v.is_some(), "sync/{i} not durable after sync_writes commit");
         }
+    }
+
+    #[tokio::test]
+    async fn empty_transaction_is_noop_not_fatal() {
+        // SlateDB rejects empty WriteBatches with "empty write batch not
+        // allowed". A no-op txn (e.g. sub-chunk trim on a fully sparse range)
+        // must short-circuit before reaching the db.
+        let fs = make_fs().await;
+        let txn = Transaction::new();
+        assert!(txn.is_empty());
+        fs.write_coordinator
+            .commit(txn)
+            .await
+            .expect("empty txn should commit as a no-op");
     }
 
     #[tokio::test]

--- a/zerofs/src/posix_tests.rs
+++ b/zerofs/src/posix_tests.rs
@@ -669,6 +669,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_trim_on_fully_sparse_file() {
+        let fs = create_test_fs().await;
+        let creds = test_creds();
+        let auth = AuthContext {
+            uid: 1000,
+            gid: 1000,
+            gids: vec![1000],
+        };
+
+        let (file_id, _) = fs
+            .create(&creds, 0, b"sparse.img", &SetAttributes::default())
+            .await
+            .unwrap();
+
+        fs.setattr(
+            &creds,
+            file_id,
+            &SetAttributes {
+                size: SetSize::Set(50 * 1024 * 1024),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        fs.trim(&auth, file_id, 0, 1024)
+            .await
+            .expect("trim on sparse file must succeed");
+    }
+
+    #[tokio::test]
     async fn test_sparse_file_operations() {
         let fs = create_test_fs().await;
         let creds = test_creds();


### PR DESCRIPTION
Fixes https://github.com/Barre/ZeroFS/issues/404