### PR TITLE
Support writing generated config to stdout via "init -"

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ cargo install zerofs
 #### Via Docker
 ```bash
 docker pull ghcr.io/barre/zerofs:latest
+
+# Generate a starter config on the host (pass "-" to write to stdout)
+docker run --rm ghcr.io/barre/zerofs:latest init - > zerofs.toml
+
+# Edit it, then run ZeroFS with the config mounted in
+$EDITOR zerofs.toml
+docker run --rm -v "$PWD/zerofs.toml:/zerofs.toml" \
+  ghcr.io/barre/zerofs:latest run -c /zerofs.toml
 ```
 
 ### Getting Started

--- a/zerofs/src/cli/mod.rs
+++ b/zerofs/src/cli/mod.rs
@@ -25,6 +25,7 @@ pub struct Cli {
 pub enum Commands {
     /// Generate a default configuration file
     Init {
+        /// Output path for the config file, or "-" to write to stdout
         #[arg(default_value = "zerofs.toml")]
         path: PathBuf,
     },

--- a/zerofs/src/config.rs
+++ b/zerofs/src/config.rs
@@ -614,7 +614,7 @@ impl Settings {
         }
     }
 
-    pub fn write_default_config(path: impl AsRef<std::path::Path>) -> Result<()> {
+    pub fn render_default_config() -> Result<String> {
         let default = Self::generate_default();
         let mut toml_string = toml::to_string_pretty(&default)?;
 
@@ -749,7 +749,11 @@ impl Settings {
             toml_string
         );
 
-        fs::write(path, commented)?;
+        Ok(commented)
+    }
+
+    pub fn write_default_config(path: impl AsRef<std::path::Path>) -> Result<()> {
+        fs::write(path, Self::render_default_config()?)?;
         Ok(())
     }
 }

--- a/zerofs/src/main.rs
+++ b/zerofs/src/main.rs
@@ -46,10 +46,16 @@ async fn main() -> Result<()> {
 
     match cli.command {
         cli::Commands::Init { path } => {
-            println!("Generating configuration file at: {}", path.display());
-            config::Settings::write_default_config(&path)?;
-            println!("Configuration file created successfully!");
-            println!("Edit the file and run: zerofs run -c {}", path.display());
+            if path.to_str() == Some("-") {
+                // Write the config to stdout so it can be piped or redirected, e.g.:
+                //   docker run --rm ghcr.io/barre/zerofs:latest init - > zerofs.toml
+                print!("{}", config::Settings::render_default_config()?);
+            } else {
+                eprintln!("Generating configuration file at: {}", path.display());
+                config::Settings::write_default_config(&path)?;
+                eprintln!("Configuration file created successfully!");
+                eprintln!("Edit the file and run: zerofs run -c {}", path.display());
+            }
         }
         cli::Commands::ChangePassword { config } => {
             let settings = match config::Settings::from_file(&config) {


### PR DESCRIPTION
Teaches `zerofs init` to emit the generated config to stdout when the path is `-`, so it can be piped or redirected. This makes the Docker pattern from #188 work:

```bash
docker run --rm ghcr.io/barre/zerofs:latest init - > zerofs.toml
```

- `init -` prints the rendered config to stdout; status messages go to stderr so a redirect yields a clean file.
- File mode (`init [PATH]`, default `zerofs.toml`) is unchanged and produces byte-identical output.
- Also sidesteps the latent failure where `docker run ... init` (no args) errored because the image CWD is `/` and the `zerofs` user cannot write there.

Closes #188