### PR TITLE
fix: scope jemalloc background thread config

### DIFF
--- a/zerofs/.cargo/config.toml
+++ b/zerofs/.cargo/config.toml
@@ -13,3 +13,6 @@ rustflags = [
 
 [env]
 JEMALLOC_SYS_WITH_MALLOC_CONF = "retain:true,dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true"
+# tikv-jemalloc-sys checks target-prefixed variables before the generic one.
+AARCH64_APPLE_DARWIN_JEMALLOC_SYS_WITH_MALLOC_CONF = "retain:true,dirty_decay_ms:1000,muzzy_decay_ms:0"
+X86_64_APPLE_DARWIN_JEMALLOC_SYS_WITH_MALLOC_CONF = "retain:true,dirty_decay_ms:1000,muzzy_decay_ms:0"


### PR DESCRIPTION
## Summary
- Keep `background_thread:true` in the generic jemalloc malloc conf so supported Linux builds retain background purging.
- Add macOS target-prefixed jemalloc malloc conf overrides without `background_thread:true`.

## Notes
- `tikv-jemalloc-sys` checks target-prefixed `JEMALLOC_SYS_WITH_MALLOC_CONF` variables before the generic one.
- This suppresses the macOS startup warning without changing the Linux allocator default.
