### PR TITLE
Support POSIX open-unlink on the 9P server via deferred inode reclamation

### DIFF
--- a/.github/workflows/pjdfstest-9p.yml
+++ b/.github/workflows/pjdfstest-9p.yml
@@ -48,12 +48,16 @@ jobs:
           # List loaded 9p modules
           lsmod | grep 9p || echo "No 9p modules loaded yet"
 
-      - name: Clone pjdfstest_nfs
+      - name: Clone pjdfstest
         run: |
-          git clone https://github.com/Barre/pjdfstest_nfs.git /tmp/pjdfstest_nfs
+          # Upstream pjdfstest (not the NFS fork): 9P supports open-unlink,
+          # open-time permission checks, and 64-bit timestamps, so it runs the
+          # full POSIX suite. The fork's nfs-incompatible carve-out is for the
+          # NFS workflow only.
+          git clone https://github.com/pjd/pjdfstest.git /tmp/pjdfstest
 
       - name: Build pjdfstest
-        working-directory: /tmp/pjdfstest_nfs
+        working-directory: /tmp/pjdfstest
         run: |
           autoreconf -fvi
           ./configure
@@ -139,7 +143,7 @@ jobs:
           cd pjdfstest_test
 
           # Get list of all test files
-          find /tmp/pjdfstest_nfs/tests -name "*.t" -type f > /tmp/all_tests.txt
+          find /tmp/pjdfstest/tests -name "*.t" -type f > /tmp/all_tests.txt
 
           # Filter out excluded tests
           grep -v -f ${{ github.workspace }}/.github/.pjdfstest-9p-exclude /tmp/all_tests.txt > /tmp/tests_to_run.txt || true

--- a/.github/workflows/pjdfstest-fuse.yml
+++ b/.github/workflows/pjdfstest-fuse.yml
@@ -43,12 +43,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential autoconf automake libtool git perl fuse3
 
-      - name: Clone pjdfstest_nfs
+      - name: Clone pjdfstest
         run: |
-          git clone https://github.com/Barre/pjdfstest_nfs.git /tmp/pjdfstest_nfs
+          # The FUSE mount rides the same 9P server, so it supports open-unlink,
+          # open-time permission checks, and 64-bit timestamps: run the full
+          # upstream suite, not the NFS fork's carved-down set.
+          git clone https://github.com/pjd/pjdfstest.git /tmp/pjdfstest
 
       - name: Build pjdfstest
-        working-directory: /tmp/pjdfstest_nfs
+        working-directory: /tmp/pjdfstest
         run: |
           autoreconf -fvi
           ./configure
@@ -141,7 +144,7 @@ jobs:
           cd pjdfstest_test
 
           # Get list of all test files
-          find /tmp/pjdfstest_nfs/tests -name "*.t" -type f > /tmp/all_tests.txt
+          find /tmp/pjdfstest/tests -name "*.t" -type f > /tmp/all_tests.txt
 
           # Filter out excluded tests
           grep -v -f ${{ github.workspace }}/.github/.pjdfstest-fuse-exclude /tmp/all_tests.txt > /tmp/tests_to_run.txt || true

--- a/zerofs/Cargo.lock
+++ b/zerofs/Cargo.lock
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "zerofs"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "zerofs-csi"
-version = "1.2.6"
+version = "1.2.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/zerofs/Cargo.toml
+++ b/zerofs/Cargo.toml
@@ -19,7 +19,7 @@ members = ["ninep-proto", "ninep-client", "zerofs-csi", "zerofs-client", "zerofs
 # same release, so the version the driver reports (GetPluginInfo) must not
 # drift from zerofs's.
 [workspace.package]
-version = "1.2.6"
+version = "1.2.7"
 
 [profile.release]
 lto = true

--- a/zerofs/src/cli/server.rs
+++ b/zerofs/src/cli/server.rs
@@ -761,8 +761,12 @@ async fn initialize_filesystem(
     .await
     .context("Failed to initialize filesystem")?;
 
+    let fs = Arc::new(fs);
+    // Reclaims open-unlinked inodes once their last open handle is dropped.
+    fs.start_reclaim_drainer();
+
     Ok(InitResult {
-        fs: Arc::new(fs),
+        fs,
         object_store,
         wal_object_store,
         db_path: actual_db_path.to_string(),

--- a/zerofs/src/failpoints.rs
+++ b/zerofs/src/failpoints.rs
@@ -12,6 +12,21 @@ pub const REMOVE_AFTER_INODE_DELETE: &str = "remove_after_inode_delete";
 pub const REMOVE_AFTER_TOMBSTONE: &str = "remove_after_tombstone";
 pub const REMOVE_AFTER_DIR_UNLINK: &str = "remove_after_dir_unlink";
 pub const REMOVE_AFTER_COMMIT: &str = "remove_after_commit";
+pub const REMOVE_AFTER_ORPHAN_ADD: &str = "remove_after_orphan_add";
+
+pub const CLUNK_AFTER_RECLAIM_INODE_DELETE: &str = "clunk_after_reclaim_inode_delete";
+
+/// `lock()`, between registering the lock and installing its guard. Pausing
+/// here drives the Tlock-vs-Tversion/clunk race in tests.
+pub const LOCK_AFTER_REGISTER_BEFORE_GUARD: &str = "lock_after_register_before_guard";
+
+/// `reclaim_if_unreferenced`, before taking the inode lock. Lets a reopen win
+/// the lock first, so reclaim's recheck must abort.
+pub const RECLAIM_BEFORE_LOCK: &str = "reclaim_before_lock";
+
+/// `reclaim_if_unreferenced`, after the recheck and holding the inode lock,
+/// before the delete. A reopen racing in here blocks, then sees the inode gone.
+pub const RECLAIM_HOLDING_LOCK_BEFORE_DELETE: &str = "reclaim_holding_lock_before_delete";
 
 pub const RENAME_AFTER_TARGET_DELETE: &str = "rename_after_target_delete";
 pub const RENAME_AFTER_SOURCE_UNLINK: &str = "rename_after_source_unlink";

--- a/zerofs/src/fs/key_codec.rs
+++ b/zerofs/src/fs/key_codec.rs
@@ -30,6 +30,7 @@ use bytes::Bytes;
 //   0x05 STATS         shard-keyed fs-wide counters
 //   0x06 SYSTEM        rare config (e.g. next-inode counter)
 //   0x07 TOMBSTONE     deferred-deletion entries, scanned only by GC
+//   0x08 ORPHAN        open-unlinked inodes pending reclaim, drained at startup
 //   0xFE CHUNK         bulk file data — the only kind in the chunk segment
 //
 // V1 keeps the same kind bytes but no domain prefix, so every kind shares
@@ -44,6 +45,7 @@ const PREFIX_DIR_COOKIE: u8 = 0x04;
 const PREFIX_STATS: u8 = 0x05;
 const PREFIX_SYSTEM: u8 = 0x06;
 const PREFIX_TOMBSTONE: u8 = 0x07;
+const PREFIX_ORPHAN: u8 = 0x08;
 const PREFIX_CHUNK: u8 = 0xFE;
 
 const SYSTEM_COUNTER_SUBTYPE: u8 = 0x01;
@@ -62,6 +64,7 @@ pub enum KeyPrefix {
     DirEntry,
     DirScan,
     Tombstone,
+    Orphan,
     Stats,
     System,
     DirCookie,
@@ -77,6 +80,7 @@ impl TryFrom<u8> for KeyPrefix {
             PREFIX_DIR_ENTRY => Ok(Self::DirEntry),
             PREFIX_DIR_SCAN => Ok(Self::DirScan),
             PREFIX_TOMBSTONE => Ok(Self::Tombstone),
+            PREFIX_ORPHAN => Ok(Self::Orphan),
             PREFIX_STATS => Ok(Self::Stats),
             PREFIX_SYSTEM => Ok(Self::System),
             PREFIX_DIR_COOKIE => Ok(Self::DirCookie),
@@ -93,6 +97,7 @@ impl From<KeyPrefix> for u8 {
             KeyPrefix::DirEntry => PREFIX_DIR_ENTRY,
             KeyPrefix::DirScan => PREFIX_DIR_SCAN,
             KeyPrefix::Tombstone => PREFIX_TOMBSTONE,
+            KeyPrefix::Orphan => PREFIX_ORPHAN,
             KeyPrefix::Stats => PREFIX_STATS,
             KeyPrefix::System => PREFIX_SYSTEM,
             KeyPrefix::DirCookie => PREFIX_DIR_COOKIE,
@@ -108,6 +113,7 @@ impl KeyPrefix {
             Self::DirEntry => "DIR_ENTRY",
             Self::DirScan => "DIR_SCAN",
             Self::Tombstone => "TOMBSTONE",
+            Self::Orphan => "ORPHAN",
             Self::Stats => "STATS",
             Self::System => "SYSTEM",
             Self::DirCookie => "DIR_COOKIE",
@@ -126,6 +132,7 @@ impl KeyPrefix {
 pub enum ParsedKey {
     DirScan { cookie: u64 },
     Tombstone { inode_id: InodeId },
+    Orphan { inode_id: InodeId },
     Unknown,
 }
 
@@ -185,6 +192,11 @@ impl KeyCodec {
     /// Total bytes in a complete tombstone key.
     pub fn tombstone_key_size(&self) -> usize {
         self.id_offset(KeyPrefix::Tombstone) + U64_SIZE * 2
+    }
+
+    /// Total bytes in a complete orphan key.
+    pub fn orphan_key_size(&self) -> usize {
+        self.id_offset(KeyPrefix::Orphan) + U64_SIZE
     }
 
     pub fn inode_key(&self, inode_id: InodeId) -> Bytes {
@@ -266,6 +278,16 @@ impl KeyCodec {
         Bytes::from(key)
     }
 
+    /// Key for an orphan-set entry. The inode_id alone keys the entry (no
+    /// timestamp, unlike tombstones): presence signals "open-unlinked, pending
+    /// reclaim", so it must be a point key the reclaim path can delete by id.
+    pub fn orphan_key(&self, inode_id: InodeId) -> Bytes {
+        let mut key = Vec::with_capacity(self.orphan_key_size());
+        self.push_prefix(&mut key, KeyPrefix::Orphan);
+        key.extend_from_slice(&inode_id.to_be_bytes());
+        Bytes::from(key)
+    }
+
     pub fn stats_shard_key(&self, shard_id: usize) -> Bytes {
         let mut key = Vec::with_capacity(self.id_offset(KeyPrefix::Stats) + U64_SIZE);
         self.push_prefix(&mut key, KeyPrefix::Stats);
@@ -307,6 +329,19 @@ impl KeyCodec {
                 }
                 if let Ok(id_bytes) = key[id_off + U64_SIZE..expected].try_into() {
                     ParsedKey::Tombstone {
+                        inode_id: u64::from_be_bytes(id_bytes),
+                    }
+                } else {
+                    ParsedKey::Unknown
+                }
+            }
+            KeyPrefix::Orphan => {
+                let expected = self.orphan_key_size();
+                if key.len() != expected {
+                    return ParsedKey::Unknown;
+                }
+                if let Ok(id_bytes) = key[id_off..expected].try_into() {
+                    ParsedKey::Orphan {
                         inode_id: u64::from_be_bytes(id_bytes),
                     }
                 } else {

--- a/zerofs/src/fs/mod.rs
+++ b/zerofs/src/fs/mod.rs
@@ -18,7 +18,7 @@ use self::key_codec::KeyCodec;
 use self::lock_manager::KeyedLockManager;
 use self::metrics::FileSystemStats;
 use self::stats::{FileSystemGlobalStats, StatsShardData};
-use self::store::{ChunkStore, DirectoryStore, InodeStore, TombstoneStore};
+use self::store::{ChunkStore, DirectoryStore, InodeStore, OrphanStore, TombstoneStore};
 use self::tracing::{AccessTracer, FileOperation};
 use self::write_coordinator::WriteCoordinator;
 use crate::db::{Db, SlateDbHandle};
@@ -26,6 +26,8 @@ use slatedb::config::{PutOptions, WriteOptions};
 use slatedb_common::metrics::DefaultMetricsRecorder;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 #[cfg(feature = "failpoints")]
 use crate::failpoints as fp;
@@ -49,6 +51,7 @@ use self::types::{
 };
 use ::tracing::{debug, error, warn};
 use bytes::Bytes;
+use dashmap::DashMap;
 use futures::pin_mut;
 use futures::stream::{self, StreamExt};
 use std::sync::atomic::Ordering;
@@ -88,6 +91,18 @@ pub struct ZeroFS {
     pub directory_store: DirectoryStore,
     pub inode_store: InodeStore,
     pub tombstone_store: TombstoneStore,
+    pub orphan_store: OrphanStore,
+    /// In-memory, process-global count of open files pinning each inode.
+    /// Empty after a restart by construction (no handle survives a crash)
+    /// Its only role is to pick the defer-vs-delete branch in `remove`/`rename`
+    pub open_handles: Arc<DashMap<InodeId, u64>>,
+    /// Reclaim queue: an `OpenHandle` drop that takes a count to zero pushes the
+    /// inode here for `start_reclaim_drainer` to reclaim.
+    pub reclaim_tx: UnboundedSender<InodeId>,
+    /// Receiver, parked until `start_reclaim_drainer` takes it (tests that don't
+    /// start the drainer just let sends buffer). `Arc<Mutex<..>>` keeps the
+    /// vestigial `ZeroFS: Clone` derive working.
+    reclaim_rx: Arc<Mutex<Option<UnboundedReceiver<InodeId>>>>,
     pub lock_manager: Arc<KeyedLockManager<InodeId>>,
     pub stats: Arc<FileSystemStats>,
     pub global_stats: Arc<FileSystemGlobalStats>,
@@ -102,6 +117,50 @@ pub struct CacheConfig {
     pub root_folder: PathBuf,
     pub max_cache_size_gb: f64,
     pub memory_cache_size_gb: Option<f64>,
+}
+
+/// Decrement `id`'s open-handle count, removing the entry at zero; returns the
+/// count after the decrement. Shared by `open_handle_dec` and `OpenHandle::drop`.
+fn dec_open_handle(map: &DashMap<InodeId, u64>, id: InodeId) -> u64 {
+    use dashmap::mapref::entry::Entry;
+    match map.entry(id) {
+        Entry::Occupied(mut e) => {
+            let v = e.get().saturating_sub(1);
+            if v == 0 {
+                e.remove();
+                0
+            } else {
+                *e.get_mut() = v;
+                v
+            }
+        }
+        Entry::Vacant(_) => 0,
+    }
+}
+
+/// Pins an inode's open-handle count for the lifetime of one opened 9P fid.
+/// Created (incrementing the count) when a fid is opened, and stored in that
+/// fid's slot in the session table. Because it lives in the slot, every way a
+/// fid goes away — clunk, close_all, a walk that overwrites it, the session
+/// table being dropped — releases the count exactly once, with no release call
+/// to forget or get wrong. Holds only the count map and the reclaim sender, not
+/// the fs, so it forms no reference cycle.
+#[derive(Debug)]
+pub struct OpenHandle {
+    inode_id: InodeId,
+    open_handles: Arc<DashMap<InodeId, u64>>,
+    reclaim_tx: UnboundedSender<InodeId>,
+}
+
+impl Drop for OpenHandle {
+    fn drop(&mut self) {
+        if dec_open_handle(&self.open_handles, self.inode_id) == 0 {
+            // Last handle gone. Reclaim takes the inode lock and is async, so it
+            // can't run in Drop; hand the inode to the drainer instead. A failed
+            // send (no drainer, or shutdown) is fine — startup drain reclaims it.
+            let _ = self.reclaim_tx.send(self.inode_id);
+        }
+    }
 }
 
 impl ZeroFS {
@@ -181,6 +240,7 @@ impl ZeroFS {
         let directory_store = DirectoryStore::new(db.clone(), key_codec.clone());
         let inode_store = InodeStore::new(db.clone(), key_codec.clone(), next_inode_id);
         let tombstone_store = TombstoneStore::new(db.clone(), key_codec.clone());
+        let orphan_store = OrphanStore::new(db.clone(), key_codec.clone());
         let write_coordinator = WriteCoordinator::new(
             db.clone(),
             inode_store.clone(),
@@ -190,12 +250,18 @@ impl ZeroFS {
             sync_writes,
         );
 
+        let (reclaim_tx, reclaim_rx) = tokio::sync::mpsc::unbounded_channel();
+
         let fs = Self {
             db: db.clone(),
             chunk_store,
             directory_store,
             inode_store,
             tombstone_store,
+            orphan_store,
+            open_handles: Arc::new(DashMap::new()),
+            reclaim_tx,
+            reclaim_rx: Arc::new(Mutex::new(Some(reclaim_rx))),
             lock_manager,
             stats,
             global_stats,
@@ -204,6 +270,13 @@ impl ZeroFS {
             max_bytes,
             tracer: AccessTracer::new(),
         };
+
+        // Drain the durable orphan set left by any prior life: open-unlinked
+        // inodes whose handles did not survive the crash/shutdown. Post-crash
+        // there are zero open handles, so every orphan is reclaimable.
+        if !db.is_read_only() {
+            fs.drain_orphans().await?;
+        }
 
         Ok(fs)
     }
@@ -280,6 +353,200 @@ impl ZeroFS {
             true,
         )
         .await
+    }
+
+    /// Increment the open-handle count for `id`. MUST be invoked under
+    /// `lock_manager.acquire(id)` together with the inode-liveness `get`, so
+    /// that the increment and the "is the inode alive" check are serialized
+    /// against `remove`/`rename`'s defer-vs-delete decision on the same id.
+    pub fn open_handle_inc(&self, id: InodeId) {
+        *self.open_handles.entry(id).or_insert(0) += 1;
+    }
+
+    /// Decrement the open-handle count, returning the count after. Only the
+    /// `handle_closed` test path uses this; production decrements via the
+    /// `OpenHandle` guard's drop.
+    #[allow(dead_code)]
+    pub fn open_handle_dec(&self, id: InodeId) -> u64 {
+        dec_open_handle(&self.open_handles, id)
+    }
+
+    /// Current open-handle count for `id`. Consulted by `remove`/`rename`
+    /// under the inode lock to choose defer-vs-delete.
+    pub fn open_handle_count(&self, id: InodeId) -> u64 {
+        self.open_handles.get(&id).map(|r| *r).unwrap_or(0)
+    }
+
+    /// Increment the open-handle count and return a guard that releases it on
+    /// drop; the caller stores it in the fid slot. Like `open_handle_inc`, must
+    /// be called under `lock_manager.acquire(id)` alongside the liveness `get`,
+    /// so the increment is ordered against `remove`/`rename`'s defer decision.
+    pub fn new_open_handle(&self, id: InodeId) -> OpenHandle {
+        self.open_handle_inc(id);
+        OpenHandle {
+            inode_id: id,
+            open_handles: self.open_handles.clone(),
+            reclaim_tx: self.reclaim_tx.clone(),
+        }
+    }
+
+    /// Spawn the reclaim drainer; call once after wrapping the fs in an `Arc`.
+    /// It holds a `Weak` ref, so it adds no cycle and exits when the fs drops,
+    /// and reclaims each inode an `OpenHandle` drop flagged as losing its last
+    /// handle. Reclaim is idempotent, so duplicate/stale ids are harmless.
+    pub fn start_reclaim_drainer(self: &Arc<Self>) {
+        let mut rx = match self.reclaim_rx.lock().unwrap().take() {
+            Some(rx) => rx,
+            None => return, // already started
+        };
+        let weak = Arc::downgrade(self);
+        tokio::spawn(async move {
+            while let Some(id) = rx.recv().await {
+                match weak.upgrade() {
+                    Some(fs) => fs.reclaim_if_unreferenced(id).await,
+                    None => break,
+                }
+            }
+        });
+    }
+
+    /// Synchronous decrement-then-reclaim. Production drives this through the
+    /// `OpenHandle` guard (drop decrements) and the drainer; this entry point is
+    /// kept for tests that want the reclaim to happen inline, with no drainer.
+    #[allow(dead_code)]
+    pub async fn handle_closed(&self, id: InodeId) {
+        // Decrement outside the lock; reclaim_if_unreferenced re-reads the count
+        // (and nlink) under it.
+        if self.open_handle_dec(id) > 0 {
+            return;
+        }
+        self.reclaim_if_unreferenced(id).await;
+    }
+
+    /// Reclaim `id` if it's now an unreferenced orphan. The count has already
+    /// been decremented by the caller; re-check it under the inode lock (a reopen
+    /// between the dec and the lock may have bumped it back up) and only reclaim
+    /// at zero.
+    pub async fn reclaim_if_unreferenced(&self, id: InodeId) {
+        #[cfg(feature = "failpoints")]
+        fail_point!(fp::RECLAIM_BEFORE_LOCK);
+
+        let _guard = self.lock_manager.acquire(id).await;
+
+        if self.open_handle_count(id) > 0 {
+            return;
+        }
+
+        #[cfg(feature = "failpoints")]
+        fail_point!(fp::RECLAIM_HOLDING_LOCK_BEFORE_DELETE);
+
+        if let Err(e) = self.reclaim_orphan_inode(id).await {
+            error!("Deferred reclaim of orphan inode {} failed: {:?}", id, e);
+        }
+    }
+
+    /// Reclaim a single deferred-orphan inode `id`: delete its inode record,
+    /// its chunks (small files) or add a tombstone (large files), subtract its
+    /// stats, and remove its orphan-set entry.
+    async fn reclaim_orphan_inode(&self, id: InodeId) -> Result<(), FsError> {
+        match self.inode_store.get(id).await {
+            Ok(Inode::File(file)) if file.nlink == 0 => {
+                let mut txn = self.db.new_transaction()?;
+                let total_chunks = file.size.div_ceil(CHUNK_SIZE as u64);
+                if total_chunks as usize <= SMALL_FILE_TOMBSTONE_THRESHOLD {
+                    self.chunk_store.delete_range(&mut txn, id, 0, total_chunks);
+                } else {
+                    self.tombstone_store.add(&mut txn, id, file.size);
+                    self.stats
+                        .tombstones_created
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                self.inode_store.delete(&mut txn, id);
+
+                #[cfg(feature = "failpoints")]
+                fail_point!(fp::CLUNK_AFTER_RECLAIM_INODE_DELETE);
+
+                txn.add_stats_delta(id, stats::size_delta(file.size, 0), -1);
+                self.orphan_store.remove(&mut txn, id);
+                self.write_coordinator.commit(txn).await?;
+                self.stats.files_deleted.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Ok(Inode::Symlink(s)) if s.nlink == 0 => {
+                // Dataless orphan
+                let mut txn = self.db.new_transaction()?;
+                self.inode_store.delete(&mut txn, id);
+
+                #[cfg(feature = "failpoints")]
+                fail_point!(fp::CLUNK_AFTER_RECLAIM_INODE_DELETE);
+
+                txn.add_stats_delta(id, stats::size_delta(0, 0), -1);
+                self.orphan_store.remove(&mut txn, id);
+                self.write_coordinator.commit(txn).await?;
+                self.stats.links_deleted.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Ok(Inode::Fifo(s))
+            | Ok(Inode::Socket(s))
+            | Ok(Inode::CharDevice(s))
+            | Ok(Inode::BlockDevice(s))
+                if s.nlink == 0 =>
+            {
+                // Dataless orphan
+                let mut txn = self.db.new_transaction()?;
+                self.inode_store.delete(&mut txn, id);
+
+                #[cfg(feature = "failpoints")]
+                fail_point!(fp::CLUNK_AFTER_RECLAIM_INODE_DELETE);
+
+                txn.add_stats_delta(id, stats::size_delta(0, 0), -1);
+                self.orphan_store.remove(&mut txn, id);
+                self.write_coordinator.commit(txn).await?;
+                Ok(())
+            }
+            Ok(_) | Err(FsError::NotFound) => {
+                // Not a reclaimable orphan (still linked, or already gone). This
+                // runs on the last clunk of EVERY opened inode (normal files,
+                // dirs), so only touch the DB when there is actually a stray
+                // orphan key to clear — never commit a no-op txn on this path.
+                if self.orphan_store.contains(id).await? {
+                    let mut txn = self.db.new_transaction()?;
+                    self.orphan_store.remove(&mut txn, id);
+                    self.write_coordinator.commit(txn).await?;
+                }
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Drain the durable orphan set at startup. Every entry is reclaimable
+    /// because no open handle survives a restart. Each reclaim is serialized
+    /// on its inode id and is idempotent, so a crash mid-drain is safe: the
+    /// not-yet-processed orphan keys are re-scanned on the next boot.
+    async fn drain_orphans(&self) -> anyhow::Result<()> {
+        let mut ids = Vec::new();
+        {
+            let stream = self.orphan_store.list().await?;
+            pin_mut!(stream);
+            while let Some(entry) = stream.next().await {
+                match entry {
+                    Ok(id) => ids.push(id),
+                    Err(e) => {
+                        warn!("Skipping unreadable orphan-set entry during drain: {:?}", e);
+                    }
+                }
+            }
+        }
+
+        for id in ids {
+            let _guard = self.lock_manager.acquire(id).await;
+            if let Err(e) = self.reclaim_orphan_inode(id).await {
+                error!("Startup drain of orphan inode {} failed: {:?}", id, e);
+            }
+        }
+
+        Ok(())
     }
 
     pub async fn is_ancestor_of(
@@ -1276,11 +1543,17 @@ impl ZeroFS {
         }
 
         let (now_sec, now_nsec) = get_current_time();
+        // True when we are resurrecting an open-unlinked inode (nlink 0 -> 1):
+        // linkat(AT_EMPTY_PATH) can give a name back to a file held open after
+        // its last unlink. It's no longer an orphan, so its durable orphan-set
+        // key must be cleared in this same txn.
+        let resurrected;
         match &mut file_inode {
             Inode::File(file) => {
                 if file.nlink == MAX_HARDLINKS_PER_INODE {
                     return Err(FsError::TooManyLinks);
                 }
+                resurrected = file.nlink == 0;
                 file.nlink += 1;
                 if file.nlink > 1 {
                     file.parent = None;
@@ -1296,6 +1569,7 @@ impl ZeroFS {
                 if special.nlink == MAX_HARDLINKS_PER_INODE {
                     return Err(FsError::TooManyLinks);
                 }
+                resurrected = special.nlink == 0;
                 special.nlink += 1;
                 if special.nlink > 1 {
                     special.parent = None;
@@ -1305,6 +1579,10 @@ impl ZeroFS {
                 special.ctime_nsec = now_nsec;
             }
             _ => unreachable!(),
+        }
+
+        if resurrected {
+            self.orphan_store.remove(&mut txn, fileid);
         }
 
         self.inode_store.save(&mut txn, fileid, &file_inode)?;
@@ -2009,6 +2287,12 @@ impl ZeroFS {
                 let mut txn = self.db.new_transaction()?;
                 let (now_sec, now_nsec) = get_current_time();
 
+                // Set when the last link is dropped but a 9P fid still holds
+                // the inode open: the inode + chunks are kept and recorded in
+                // the durable orphan set, and the stats subtraction is deferred
+                // to reclaim (the storage is still live). The namespace effect
+                // (entry gone, nlink=0) is committed as durably as ever.
+                let mut deferred = false;
                 match &mut file_inode {
                     Inode::File(file) => {
                         if file.nlink > 1 {
@@ -2017,6 +2301,24 @@ impl ZeroFS {
                             file.ctime_nsec = now_nsec;
 
                             self.inode_store.save(&mut txn, file_id, &file_inode)?;
+                        } else if self.open_handle_count(file_id) > 0 {
+                            // POSIX open-unlink: defer reclaim until last clunk.
+                            file.nlink = 0;
+                            file.ctime = now_sec;
+                            file.ctime_nsec = now_nsec;
+                            // Detach from the namespace (the dir entry is being
+                            // removed below) so write()/setattr() through the
+                            // still-open fid do not try to update a now-gone
+                            // directory entry, same representation hardlinked
+                            // (nlink>1) files already use.
+                            file.parent = None;
+                            file.name = None;
+                            self.inode_store.save(&mut txn, file_id, &file_inode)?;
+                            self.orphan_store.add(&mut txn, file_id);
+                            deferred = true;
+
+                            #[cfg(feature = "failpoints")]
+                            fail_point!(fp::REMOVE_AFTER_ORPHAN_ADD);
                         } else {
                             let total_chunks = file.size.div_ceil(CHUNK_SIZE as u64);
 
@@ -2060,9 +2362,24 @@ impl ZeroFS {
                             .directories_deleted
                             .fetch_add(1, Ordering::Relaxed);
                     }
-                    Inode::Symlink(_) => {
-                        self.inode_store.delete(&mut txn, file_id);
-                        self.stats.links_deleted.fetch_add(1, Ordering::Relaxed);
+                    Inode::Symlink(symlink) => {
+                        if self.open_handle_count(file_id) > 0 {
+                            // POSIX open-unlink: defer reclaim until last clunk.
+                            symlink.nlink = 0;
+                            symlink.ctime = now_sec;
+                            symlink.ctime_nsec = now_nsec;
+                            symlink.parent = None;
+                            symlink.name = None;
+                            self.inode_store.save(&mut txn, file_id, &file_inode)?;
+                            self.orphan_store.add(&mut txn, file_id);
+                            deferred = true;
+
+                            #[cfg(feature = "failpoints")]
+                            fail_point!(fp::REMOVE_AFTER_ORPHAN_ADD);
+                        } else {
+                            self.inode_store.delete(&mut txn, file_id);
+                            self.stats.links_deleted.fetch_add(1, Ordering::Relaxed);
+                        }
                     }
                     Inode::Fifo(special)
                     | Inode::Socket(special)
@@ -2074,6 +2391,19 @@ impl ZeroFS {
                             special.ctime_nsec = now_nsec;
 
                             self.inode_store.save(&mut txn, file_id, &file_inode)?;
+                        } else if self.open_handle_count(file_id) > 0 {
+                            // POSIX open-unlink: defer reclaim until last clunk.
+                            special.nlink = 0;
+                            special.ctime = now_sec;
+                            special.ctime_nsec = now_nsec;
+                            special.parent = None;
+                            special.name = None;
+                            self.inode_store.save(&mut txn, file_id, &file_inode)?;
+                            self.orphan_store.add(&mut txn, file_id);
+                            deferred = true;
+
+                            #[cfg(feature = "failpoints")]
+                            fail_point!(fp::REMOVE_AFTER_ORPHAN_ADD);
                         } else {
                             self.inode_store.delete(&mut txn, file_id);
                         }
@@ -2111,7 +2441,9 @@ impl ZeroFS {
                     _ => (None, false),
                 };
 
-                if should_always_remove_stats || original_nlink <= 1 {
+                // When deferred, the inode's storage is still live; its stats
+                // are subtracted at reclaim (last clunk / startup drain).
+                if !deferred && (should_always_remove_stats || original_nlink <= 1) {
                     txn.add_stats_delta(file_id, stats::size_delta(file_size.unwrap_or(0), 0), -1);
                 }
 
@@ -2309,6 +2641,12 @@ impl ZeroFS {
                     | Inode::BlockDevice(s) => (s.nlink, None, false),
                 };
 
+            // Set when the clobbered target's last link is dropped while a 9P
+            // fid still holds it open: defer reclaim exactly like remove().
+            // Declared before the macro so the macro body (which sets it) can
+            // resolve it under macro_rules hygiene.
+            let mut target_deferred = false;
+
             macro_rules! handle_special_file {
                 ($special:expr, $inode_variant:ident) => {
                     if $special.nlink > 1 {
@@ -2322,6 +2660,21 @@ impl ZeroFS {
                             target_id,
                             &Inode::$inode_variant($special),
                         )?;
+                    } else if self.open_handle_count(target_id) > 0 {
+                        // POSIX open-unlink on a rename-clobbered special file.
+                        $special.nlink = 0;
+                        let (now_sec, now_nsec) = get_current_time();
+                        $special.ctime = now_sec;
+                        $special.ctime_nsec = now_nsec;
+                        $special.parent = None;
+                        $special.name = None;
+                        self.inode_store.save(
+                            &mut txn,
+                            target_id,
+                            &Inode::$inode_variant($special),
+                        )?;
+                        self.orphan_store.add(&mut txn, target_id);
+                        target_deferred = true;
                     } else {
                         self.inode_store.delete(&mut txn, target_id);
                     }
@@ -2338,6 +2691,23 @@ impl ZeroFS {
 
                         self.inode_store
                             .save(&mut txn, target_id, &Inode::File(file))?;
+                    } else if self.open_handle_count(target_id) > 0 {
+                        // POSIX open-unlink on a rename-clobbered target.
+                        file.nlink = 0;
+                        let (now_sec, now_nsec) = get_current_time();
+                        file.ctime = now_sec;
+                        file.ctime_nsec = now_nsec;
+                        // Detach from the namespace: the target's dir entry is
+                        // about to be reused by the source inode, so the target
+                        // must not retain (to_dirid, to_name) — otherwise a
+                        // write through its open fid would clobber the renamed
+                        // entry. Mirror the hardlink (nlink>1) representation.
+                        file.parent = None;
+                        file.name = None;
+                        self.inode_store
+                            .save(&mut txn, target_id, &Inode::File(file))?;
+                        self.orphan_store.add(&mut txn, target_id);
+                        target_deferred = true;
                     } else {
                         let total_chunks = file.size.div_ceil(CHUNK_SIZE as u64);
 
@@ -2358,8 +2728,22 @@ impl ZeroFS {
                     self.inode_store.delete(&mut txn, target_id);
                     self.directory_store.delete_directory(&mut txn, target_id);
                 }
-                Inode::Symlink(_) => {
-                    self.inode_store.delete(&mut txn, target_id);
+                Inode::Symlink(mut symlink) => {
+                    if self.open_handle_count(target_id) > 0 {
+                        // POSIX open-unlink on a rename-clobbered symlink.
+                        symlink.nlink = 0;
+                        let (now_sec, now_nsec) = get_current_time();
+                        symlink.ctime = now_sec;
+                        symlink.ctime_nsec = now_nsec;
+                        symlink.parent = None;
+                        symlink.name = None;
+                        self.inode_store
+                            .save(&mut txn, target_id, &Inode::Symlink(symlink))?;
+                        self.orphan_store.add(&mut txn, target_id);
+                        target_deferred = true;
+                    } else {
+                        self.inode_store.delete(&mut txn, target_id);
+                    }
                 }
                 Inode::Fifo(mut special) => {
                     handle_special_file!(special, Fifo);
@@ -2379,8 +2763,10 @@ impl ZeroFS {
             fail_point!(fp::RENAME_AFTER_TARGET_DELETE);
 
             // For directories and symlinks: always remove from stats
-            // For files and special files: only remove if this is the last link
-            if should_always_remove_stats || original_nlink <= 1 {
+            // For files and special files: only remove if this is the last link.
+            // When deferred, the target's storage is still live; its stats are
+            // subtracted at reclaim (last clunk / startup drain).
+            if !target_deferred && (should_always_remove_stats || original_nlink <= 1) {
                 txn.add_stats_delta(
                     target_id,
                     stats::size_delta(original_file_size.unwrap_or(0), 0),
@@ -4022,5 +4408,437 @@ mod tests {
         assert_eq!(hardlink.attr.size, 12);
         assert_eq!(original.attr.nlink, 2);
         assert_eq!(hardlink.attr.nlink, 2);
+    }
+
+    // ---- POSIX open-unlink (deferred reclaim) ----
+
+    async fn orphan_ids(fs: &ZeroFS) -> Vec<InodeId> {
+        let stream = fs.orphan_store.list().await.unwrap();
+        pin_mut!(stream);
+        let mut ids = Vec::new();
+        while let Some(r) = stream.next().await {
+            ids.push(r.unwrap());
+        }
+        ids
+    }
+
+    async fn make_file(fs: &ZeroFS, name: &[u8], contents: &[u8]) -> InodeId {
+        let (id, _) = fs
+            .create(&test_creds(), 0, name, &SetAttributes::default())
+            .await
+            .unwrap();
+        fs.write(
+            &(&test_auth()).into(),
+            id,
+            0,
+            &Bytes::copy_from_slice(contents),
+        )
+        .await
+        .unwrap();
+        id
+    }
+
+    /// The deterministic repro: open a fid, unlink the name, the open fid must
+    /// still read the data; only the last clunk reclaims the inode.
+    #[tokio::test]
+    async fn test_open_unlink_read_via_open_fid() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let data = b"open-unlink contents";
+        let file_id = make_file(&fs, b"a", data).await;
+
+        // `exec 3< a`
+        fs.open_handle_inc(file_id);
+
+        // `rm a` — defers because a handle is open.
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap();
+        assert_eq!(orphan_ids(&fs).await, vec![file_id]);
+        // Name is gone from the namespace.
+        assert!(matches!(
+            fs.lookup(&test_creds(), 0, b"a").await,
+            Err(FsError::NotFound)
+        ));
+
+        // `cat <&3` — read through the still-open fid succeeds.
+        let (read, _) = fs
+            .read_file(&(&test_auth()).into(), file_id, 0, data.len() as u32)
+            .await
+            .unwrap();
+        assert_eq!(read.as_ref(), data);
+
+        // Write through the still-open fid after unlink must also succeed
+        // (POSIX open-unlink covers read AND write).
+        fs.write(
+            &(&test_auth()).into(),
+            file_id,
+            0,
+            &Bytes::copy_from_slice(b"WROTE-AFTER-UNLINK!!"),
+        )
+        .await
+        .expect("write after unlink must succeed");
+
+        // fd 3 closes — last handle, reclaim now.
+        fs.handle_closed(file_id).await;
+        assert!(matches!(
+            fs.inode_store.get(file_id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    // A reopen that bumps the count before reclaim's recheck must make the
+    // recheck abort — reclaim must never delete a re-referenced inode. A
+    // failpoint pauses reclaim before it takes the inode lock so the reopen wins
+    // the lock deterministically. Run with `--features failpoints`.
+    #[cfg(feature = "failpoints")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_reclaim_aborts_on_concurrent_reopen() {
+        let _scenario = fail::FailScenario::setup();
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let file_id = make_file(&fs, b"a", b"data").await;
+        fs.open_handle_inc(file_id); // a handle is open
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap(); // defer -> orphan
+        fs.open_handle_dec(file_id); // last handle closed -> count 0, reclaimable
+        assert_eq!(orphan_ids(&fs).await, vec![file_id]);
+
+        fail::cfg(fp::RECLAIM_BEFORE_LOCK, "pause").unwrap();
+        let f = fs.clone();
+        let reclaim = tokio::spawn(async move { f.reclaim_if_unreferenced(file_id).await });
+
+        // Let reclaim reach the pause, then reopen: take the inode lock and bump
+        // the count exactly as lopen does (acquire + open_handle_inc).
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        {
+            let _g = fs.lock_manager.acquire(file_id).await;
+            fs.open_handle_inc(file_id);
+        }
+
+        // Resume reclaim: acquires the lock, rechecks count > 0, must abort.
+        fail::cfg(fp::RECLAIM_BEFORE_LOCK, "off").unwrap();
+        reclaim.await.unwrap();
+
+        assert!(
+            fs.inode_store.get(file_id).await.is_ok(),
+            "reclaim must abort when a reopen raced in before the recheck"
+        );
+        assert_eq!(fs.open_handle_count(file_id), 1);
+        assert_eq!(orphan_ids(&fs).await, vec![file_id]);
+    }
+
+    // The other ordering: a reopen that races into the reclaim window blocks on
+    // the inode lock reclaim holds, then sees the inode gone once reclaim deletes
+    // it — a clean failure, not a dangling reference. A failpoint pauses reclaim
+    // while it holds the lock, after the recheck.
+    #[cfg(feature = "failpoints")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_reopen_after_reclaim_fails_cleanly() {
+        let _scenario = fail::FailScenario::setup();
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let file_id = make_file(&fs, b"a", b"data").await;
+        fs.open_handle_inc(file_id);
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap();
+        fs.open_handle_dec(file_id);
+
+        fail::cfg(fp::RECLAIM_HOLDING_LOCK_BEFORE_DELETE, "pause").unwrap();
+        let f = fs.clone();
+        let reclaim = tokio::spawn(async move { f.reclaim_if_unreferenced(file_id).await });
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+        // Reopen races in and blocks on the inode lock reclaim is holding.
+        let f2 = fs.clone();
+        let reopen = tokio::spawn(async move {
+            let _g = f2.lock_manager.acquire(file_id).await;
+            f2.inode_store.get(file_id).await // the liveness check lopen does
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+        // Resume reclaim: it deletes the inode and releases the lock; the reopen
+        // then proceeds and must see the inode gone.
+        fail::cfg(fp::RECLAIM_HOLDING_LOCK_BEFORE_DELETE, "off").unwrap();
+        reclaim.await.unwrap();
+        let reopen_result = reopen.await.unwrap();
+
+        assert!(
+            matches!(reopen_result, Err(FsError::NotFound)),
+            "a reopen racing into the reclaim window must see the inode gone, not a dangling reference"
+        );
+        assert!(matches!(
+            fs.inode_store.get(file_id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    /// Open-unlink also covers special files: a FIFO unlinked while a handle is
+    /// open is deferred to the orphan set, then reclaimed at last clunk.
+    #[tokio::test]
+    async fn test_open_unlink_fifo_defers_and_reclaims() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let (id, _) = fs
+            .mknod(
+                &test_creds(),
+                0,
+                b"p",
+                FileType::Fifo,
+                &SetAttributes::default(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        fs.open_handle_inc(id);
+        fs.remove(&(&test_auth()).into(), 0, b"p").await.unwrap();
+        // Deferred: name gone, inode kept alive, in the orphan set.
+        assert_eq!(orphan_ids(&fs).await, vec![id]);
+        assert!(matches!(
+            fs.lookup(&test_creds(), 0, b"p").await,
+            Err(FsError::NotFound)
+        ));
+        assert!(fs.inode_store.get(id).await.is_ok());
+
+        // Last clunk reclaims it.
+        fs.handle_closed(id).await;
+        assert!(matches!(
+            fs.inode_store.get(id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    /// Same for a symlink unlinked while a handle is open.
+    #[tokio::test]
+    async fn test_open_unlink_symlink_defers_and_reclaims() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let (id, _) = fs
+            .symlink(&test_creds(), 0, b"s", b"target", &SetAttributes::default())
+            .await
+            .unwrap();
+
+        fs.open_handle_inc(id);
+        fs.remove(&(&test_auth()).into(), 0, b"s").await.unwrap();
+        assert_eq!(orphan_ids(&fs).await, vec![id]);
+        assert!(matches!(
+            fs.lookup(&test_creds(), 0, b"s").await,
+            Err(FsError::NotFound)
+        ));
+        assert!(fs.inode_store.get(id).await.is_ok());
+
+        fs.handle_closed(id).await;
+        assert!(matches!(
+            fs.inode_store.get(id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    /// Unlink with no open handle keeps the original synchronous-delete path
+    /// and never touches the orphan set.
+    #[tokio::test]
+    async fn test_unlink_no_handle_deletes_immediately() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let file_id = make_file(&fs, b"a", b"data").await;
+
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap();
+        assert!(matches!(
+            fs.inode_store.get(file_id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    /// Two open handles: remove defers; the inode survives the first clunk and
+    /// is reclaimed only on the second (last) clunk.
+    #[tokio::test]
+    async fn test_open_unlink_two_handles() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let file_id = make_file(&fs, b"a", b"two-handles").await;
+
+        fs.open_handle_inc(file_id);
+        fs.open_handle_inc(file_id);
+
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap();
+        assert_eq!(orphan_ids(&fs).await, vec![file_id]);
+
+        // First clunk: still alive.
+        fs.handle_closed(file_id).await;
+        assert!(fs.inode_store.get(file_id).await.is_ok());
+        assert_eq!(orphan_ids(&fs).await, vec![file_id]);
+
+        // Second (last) clunk: reclaimed.
+        fs.handle_closed(file_id).await;
+        assert!(matches!(
+            fs.inode_store.get(file_id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    /// Reopen after defer keeps the inode alive across the original handle's
+    /// clunk; reclaim only fires when the reopened handle also closes.
+    #[tokio::test]
+    async fn test_open_unlink_reopen_before_clunk() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let file_id = make_file(&fs, b"a", b"reopen").await;
+
+        fs.open_handle_inc(file_id); // handle A
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap();
+
+        // Reopen via the still-open fid (dup): handle B.
+        fs.open_handle_inc(file_id);
+
+        // Close A: count drops to 1, no reclaim.
+        fs.handle_closed(file_id).await;
+        assert!(fs.inode_store.get(file_id).await.is_ok());
+
+        // Close B: last handle, reclaim.
+        fs.handle_closed(file_id).await;
+        assert!(matches!(
+            fs.inode_store.get(file_id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    /// rename clobbering an open target defers the target's reclaim; the
+    /// target's open fid still reads, and the last clunk reclaims it.
+    #[tokio::test]
+    async fn test_rename_over_open_target() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let src_id = make_file(&fs, b"src", b"source").await;
+        let tgt_data = b"target-contents";
+        let tgt_id = make_file(&fs, b"tgt", tgt_data).await;
+
+        fs.open_handle_inc(tgt_id);
+
+        fs.rename(&(&test_auth()).into(), 0, b"src", 0, b"tgt")
+            .await
+            .unwrap();
+        assert_eq!(orphan_ids(&fs).await, vec![tgt_id]);
+
+        // The clobbered target's open fid still reads its data.
+        let (read, _) = fs
+            .read_file(&(&test_auth()).into(), tgt_id, 0, tgt_data.len() as u32)
+            .await
+            .unwrap();
+        assert_eq!(read.as_ref(), tgt_data);
+        // The new "tgt" name resolves to the source inode.
+        let (resolved, _) = fs
+            .directory_store
+            .get_entry_with_cookie(0, b"tgt")
+            .await
+            .unwrap();
+        assert_eq!(resolved, src_id);
+
+        fs.handle_closed(tgt_id).await;
+        assert!(matches!(
+            fs.inode_store.get(tgt_id).await,
+            Err(FsError::NotFound)
+        ));
+        assert!(orphan_ids(&fs).await.is_empty());
+    }
+
+    /// linkat resurrecting an open-unlinked inode (nlink 0->1) must clear its
+    /// orphan-set key, so the last clunk does NOT reclaim a now-linked file.
+    #[tokio::test]
+    async fn test_link_resurrects_open_unlinked_clears_orphan() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let id = make_file(&fs, b"a", b"data").await;
+        fs.open_handle_inc(id);
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap();
+        assert_eq!(orphan_ids(&fs).await, vec![id]);
+
+        // Give it a name again while still open.
+        fs.link(&(&test_auth()).into(), id, 0, b"a2").await.unwrap();
+        assert!(
+            orphan_ids(&fs).await.is_empty(),
+            "link must clear the orphan-set key"
+        );
+
+        // Last clunk must not reclaim it: it's linked again.
+        fs.handle_closed(id).await;
+        assert!(
+            fs.inode_store.get(id).await.is_ok(),
+            "resurrected inode must survive its last clunk"
+        );
+        assert_eq!(fs.lookup(&test_creds(), 0, b"a2").await.unwrap(), id);
+    }
+
+    /// Rename-clobber of an OPEN symlink and an OPEN special file defers reclaim
+    /// (same as a File target) and reclaims at last clunk.
+    #[tokio::test]
+    async fn test_rename_over_open_symlink_and_special() {
+        // Symlink target.
+        {
+            let fs = ZeroFS::new_in_memory().await.unwrap();
+            make_file(&fs, b"src", b"x").await;
+            let (sym_id, _) = fs
+                .symlink(&test_creds(), 0, b"tgt", b"dest", &SetAttributes::default())
+                .await
+                .unwrap();
+            fs.open_handle_inc(sym_id);
+            fs.rename(&(&test_auth()).into(), 0, b"src", 0, b"tgt")
+                .await
+                .unwrap();
+            assert_eq!(orphan_ids(&fs).await, vec![sym_id]);
+            assert!(fs.inode_store.get(sym_id).await.is_ok());
+            fs.handle_closed(sym_id).await;
+            assert!(matches!(
+                fs.inode_store.get(sym_id).await,
+                Err(FsError::NotFound)
+            ));
+            assert!(orphan_ids(&fs).await.is_empty());
+        }
+        // FIFO (special-file) target.
+        {
+            let fs = ZeroFS::new_in_memory().await.unwrap();
+            make_file(&fs, b"src", b"x").await;
+            let (fifo_id, _) = fs
+                .mknod(
+                    &test_creds(),
+                    0,
+                    b"tgt",
+                    FileType::Fifo,
+                    &SetAttributes::default(),
+                    None,
+                )
+                .await
+                .unwrap();
+            fs.open_handle_inc(fifo_id);
+            fs.rename(&(&test_auth()).into(), 0, b"src", 0, b"tgt")
+                .await
+                .unwrap();
+            assert_eq!(orphan_ids(&fs).await, vec![fifo_id]);
+            assert!(fs.inode_store.get(fifo_id).await.is_ok());
+            fs.handle_closed(fifo_id).await;
+            assert!(matches!(
+                fs.inode_store.get(fifo_id).await,
+                Err(FsError::NotFound)
+            ));
+            assert!(orphan_ids(&fs).await.is_empty());
+        }
+    }
+
+    /// Unlinking one name of a hardlinked (nlink==2) open file only decrements
+    /// nlink; it must NOT enter the orphan set, and the inode stays fully live.
+    #[tokio::test]
+    async fn test_open_unlink_hardlinked_decrements_only() {
+        let fs = ZeroFS::new_in_memory().await.unwrap();
+        let file_id = make_file(&fs, b"a", b"hardlink").await;
+        fs.link(&(&test_auth()).into(), file_id, 0, b"b")
+            .await
+            .unwrap();
+
+        fs.open_handle_inc(file_id);
+        fs.remove(&(&test_auth()).into(), 0, b"a").await.unwrap();
+
+        // nlink dropped to 1, inode untouched, orphan set NOT written.
+        match fs.inode_store.get(file_id).await.unwrap() {
+            Inode::File(f) => assert_eq!(f.nlink, 1),
+            _ => panic!("expected file"),
+        }
+        assert!(orphan_ids(&fs).await.is_empty());
+
+        // The remaining link still works after closing the handle.
+        fs.handle_closed(file_id).await;
+        assert!(fs.inode_store.get(file_id).await.is_ok());
     }
 }

--- a/zerofs/src/fs/store/mod.rs
+++ b/zerofs/src/fs/store/mod.rs
@@ -1,9 +1,11 @@
 pub mod chunk;
 pub mod directory;
 pub mod inode;
+pub mod orphan;
 pub mod tombstone;
 
 pub use chunk::ChunkStore;
 pub use directory::DirectoryStore;
 pub use inode::InodeStore;
+pub use orphan::OrphanStore;
 pub use tombstone::TombstoneStore;

--- a/zerofs/src/fs/store/orphan.rs
+++ b/zerofs/src/fs/store/orphan.rs
@@ -1,0 +1,73 @@
+use crate::db::{Db, Transaction};
+use crate::fs::errors::FsError;
+use crate::fs::inode::InodeId;
+use crate::fs::key_codec::{KeyCodec, KeyPrefix, ParsedKey};
+use futures::Stream;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Durable set of inodes that were unlinked while a 9P fid still held them
+/// open (POSIX open-unlink). Membership means: the namespace entry is gone and
+/// nlink==0, but the inode record + chunks are intentionally kept alive so the
+/// open fid can keep reading/writing. The entry is removed in the same
+/// transaction that finally reclaims the inode (last clunk, or startup drain).
+#[derive(Clone)]
+pub struct OrphanStore {
+    db: Arc<Db>,
+    key_codec: Arc<KeyCodec>,
+}
+
+impl OrphanStore {
+    pub fn new(db: Arc<Db>, key_codec: Arc<KeyCodec>) -> Self {
+        Self { db, key_codec }
+    }
+
+    pub fn add(&self, txn: &mut Transaction, inode_id: InodeId) {
+        let key = self.key_codec.orphan_key(inode_id);
+        txn.put_bytes(&key, bytes::Bytes::new());
+    }
+
+    pub fn remove(&self, txn: &mut Transaction, inode_id: InodeId) {
+        let key = self.key_codec.orphan_key(inode_id);
+        txn.delete_bytes(&key);
+    }
+
+    /// Whether `inode_id` currently has an orphan-set entry. A point read used
+    /// to avoid committing a no-op delete txn on the hot clunk path.
+    pub async fn contains(&self, inode_id: InodeId) -> Result<bool, FsError> {
+        let key = self.key_codec.orphan_key(inode_id);
+        Ok(self
+            .db
+            .get_bytes(&key)
+            .await
+            .map_err(|_| FsError::IoError)?
+            .is_some())
+    }
+
+    pub async fn list(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<InodeId, FsError>> + Send + '_>>, FsError> {
+        let (start, end) = self.key_codec.prefix_range(KeyPrefix::Orphan);
+        let codec = self.key_codec.clone();
+
+        let iter = self
+            .db
+            .scan(start..end)
+            .await
+            .map_err(|_| FsError::IoError)?;
+
+        Ok(Box::pin(futures::stream::unfold(
+            (iter, codec),
+            |(mut iter, codec)| async move {
+                match futures::StreamExt::next(&mut iter).await {
+                    Some(Ok((key, _value))) => match codec.parse_key(&key) {
+                        ParsedKey::Orphan { inode_id } => Some((Ok(inode_id), (iter, codec))),
+                        _ => Some((Err(FsError::InvalidData), (iter, codec))),
+                    },
+                    Some(Err(_)) => Some((Err(FsError::IoError), (iter, codec))),
+                    None => None,
+                }
+            },
+        )))
+    }
+}

--- a/zerofs/src/mount.rs
+++ b/zerofs/src/mount.rs
@@ -825,7 +825,7 @@ impl Filesystem for Fuse9P {
         let locks = Arc::clone(&self.locks);
         let ino = ino.0;
         self.rt.spawn(async move {
-            locks.unlock_range(ino, LOCAL_LOCK_FID, 0, 0, owner).await;
+            locks.unlock_range(ino, LOCAL_LOCK_FID, 0, 0, owner);
             reply.ok();
         });
     }
@@ -1152,7 +1152,7 @@ impl Filesystem for Fuse9P {
                 fid: LOCAL_LOCK_FID,
                 inode_id: ino,
             };
-            if let Some(conflict) = locks.check_would_block(ino, &test, owner).await {
+            if let Some(conflict) = locks.check_would_block(ino, &test, owner) {
                 let (cs, ce) = from_9p_range(conflict.start, conflict.length);
                 reply.locked(
                     cs,
@@ -1208,9 +1208,7 @@ impl Filesystem for Fuse9P {
         let (s9, len9) = to_9p_range(start, end);
         self.rt.spawn(async move {
             if matches!(lt, LockType::Unlock) {
-                locks
-                    .unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner)
-                    .await;
+                locks.unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner);
                 let _ = client
                     .lock(server_fid, LockType::Unlock, 0, s9, len9, pid, &client_id)
                     .await;
@@ -1231,7 +1229,7 @@ impl Filesystem for Fuse9P {
                     fid: LOCAL_LOCK_FID,
                     inode_id: ino,
                 };
-                if locks.try_add_lock(owner, new_lock).await.is_none() {
+                if locks.try_add_lock(owner, new_lock).is_none() {
                     if sleep {
                         tokio::time::sleep(LOCK_POLL).await;
                         continue;
@@ -1256,16 +1254,12 @@ impl Filesystem for Fuse9P {
                     // Grace period and lock errors are not retryable (v9fs maps
                     // both to ENOLCK); roll back the local grant and fail.
                     Ok(LockStatus::Grace) | Ok(LockStatus::LockError) => {
-                        locks
-                            .unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner)
-                            .await;
+                        locks.unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner);
                         reply.error(Errno::ENOLCK);
                         return;
                     }
                     Err(e) => {
-                        locks
-                            .unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner)
-                            .await;
+                        locks.unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner);
                         reply.error(errno(&e));
                         return;
                     }
@@ -1273,9 +1267,7 @@ impl Filesystem for Fuse9P {
 
                 // The server reports a conflict with another client. Undo the
                 // local grant, then wait and retry (blocking) or report EAGAIN.
-                locks
-                    .unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner)
-                    .await;
+                locks.unlock_range(ino, LOCAL_LOCK_FID, s9, len9, owner);
                 if sleep {
                     tokio::time::sleep(LOCK_POLL).await;
                     continue;

--- a/zerofs/src/ninep/handler.rs
+++ b/zerofs/src/ninep/handler.rs
@@ -1,6 +1,7 @@
 use super::errors::{P9Error, P9Result};
-use super::lock_manager::{FileLock, FileLockManager};
-use crate::fs::ZeroFS;
+use super::lock_manager::{FileLock, FileLockManager, LockGuard};
+#[cfg(feature = "failpoints")]
+use crate::failpoints as fp;
 use crate::fs::errors::FsError;
 use crate::fs::inode::{Inode, InodeAttrs, InodeId};
 use crate::fs::permissions::{AccessMode, Credentials, check_access};
@@ -9,8 +10,12 @@ use crate::fs::types::{
     AuthContext, FileAttributes, FileType, InodeWithId, SetAttributes, SetGid, SetMode, SetSize,
     SetTime, SetUid, Timestamp,
 };
+use crate::fs::{OpenHandle, ZeroFS};
 use bytes::Bytes;
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
+#[cfg(feature = "failpoints")]
+use fp::fail_point;
 use ninep_proto::*;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering as AtomicOrdering};
@@ -70,10 +75,35 @@ pub struct Fid {
     pub creds: Credentials, // Store credentials per fid/session
 }
 
+/// A session fid-table entry: the cloneable `Fid` data, plus the guards that
+/// tie its open-handle count and byte-range locks to the entry's lifetime.
+/// `get_fid` clones out `.fid` only, so the guards stay in the table — meaning
+/// the resources are released exactly once, whenever and however the entry is
+/// dropped (clunk, close_all, an overwriting walk/open, teardown).
+#[derive(Debug)]
+pub struct FidSlot {
+    pub fid: Fid,
+    /// Present once the fid is opened; pins the inode's open-handle count.
+    pub handle: Option<OpenHandle>,
+    /// Present once the fid takes its first byte-range lock; releases the fid's
+    /// locks on drop.
+    pub lock_guard: Option<LockGuard>,
+}
+
+impl FidSlot {
+    fn unopened(fid: Fid) -> Self {
+        Self {
+            fid,
+            handle: None,
+            lock_guard: None,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Session {
     pub msize: AtomicU32,
-    pub fids: Arc<DashMap<u32, Fid>>,
+    pub fids: Arc<DashMap<u32, FidSlot>>,
     /// The inode the session's last Tattach aname resolved to (0 when the
     /// session is rooted at the whole filesystem). Trebind validates rebound
     /// inodes against this subtree.
@@ -190,7 +220,7 @@ impl NinePHandler {
             .fids
             .get(&fid)
             .ok_or(P9Error::BadFid)
-            .map(|f| f.clone())
+            .map(|s| s.fid.clone())
     }
 
     pub async fn handle_message(&self, tag: u16, msg: Message) -> P9Message {
@@ -252,9 +282,12 @@ impl NinePHandler {
 
         debug!("Client requested version: {}", version_str);
 
-        // Per 9P spec, Tversion resets all connection state.
-        // All fids are implicitly clunked and the session is reset.
-        self.session.fids.clear();
+        // Tversion implicitly clunks every fid and resets the session. Dropping
+        // the fids releases their handle counts (reclaiming any now-last
+        // open-unlinked inode) and their locks; the explicit lock sweep is a
+        // safety net in case some path ever leaves a lock without a guard.
+        self.close_all_open_handles();
+        self.lock_manager.release_session_locks(self.handler_id);
         self.session.attach_root.store(0, AtomicOrdering::Relaxed);
 
         if !version_str.contains("9P2000.L") {
@@ -366,7 +399,7 @@ impl NinePHandler {
             .store(root_id, AtomicOrdering::Relaxed);
         self.session.fids.insert(
             ta.fid,
-            Fid {
+            FidSlot::unopened(Fid {
                 // The fid's path stays absolute (rename resolves it from
                 // inode 0), so it starts at the aname components.
                 path: components
@@ -379,7 +412,7 @@ impl NinePHandler {
                 opened: false,
                 mode: None,
                 creds,
-            },
+            }),
         );
 
         Ok(Message::Rattach(Rattach { qid }))
@@ -438,7 +471,7 @@ impl NinePHandler {
 
         self.session.fids.insert(
             tr.fid,
-            Fid {
+            FidSlot::unopened(Fid {
                 path,
                 inode_id: tr.inode_id,
                 root: attach_root,
@@ -446,7 +479,7 @@ impl NinePHandler {
                 opened: false,
                 mode: None,
                 creds,
-            },
+            }),
         );
 
         Ok(Message::Rrebind(Rrebind { qid }))
@@ -579,7 +612,11 @@ impl NinePHandler {
                 mode: None,
                 creds: src_fid.creds, // Inherit credentials from source fid
             };
-            self.session.fids.insert(tw.newfid, new_fid);
+            // An in-place walk (newfid == fid) overwrites the slot; if it held an
+            // open handle, the old guard drops here and releases the count.
+            self.session
+                .fids
+                .insert(tw.newfid, FidSlot::unopened(new_fid));
         }
 
         Ok(Message::Rwalk(Rwalk {
@@ -616,7 +653,7 @@ impl NinePHandler {
         }
         self.session.fids.insert(
             tw.newfid,
-            Fid {
+            FidSlot::unopened(Fid {
                 path: current_path,
                 inode_id: current_id,
                 root: src_fid.root,
@@ -624,7 +661,7 @@ impl NinePHandler {
                 opened: false,
                 mode: None,
                 creds: src_fid.creds,
-            },
+            }),
         );
 
         // For a named walk the final inode is already in hand; an empty walk
@@ -655,15 +692,36 @@ impl NinePHandler {
             tl.fid, inode_id, creds.uid, creds.gid, tl.flags
         );
 
-        let inode = self.filesystem.inode_store.get(inode_id).await?;
+        // Liveness check + open + handle-guard install, all under the inode lock
+        // so the increment is ordered against remove/rename's defer decision.
+        let inode = {
+            let _guard = self.filesystem.lock_manager.acquire(inode_id).await;
+            let inode = self.filesystem.inode_store.get(inode_id).await?;
+            let qid = inode_to_qid(&inode, inode_id);
+            match self.session.fids.get_mut(&tl.fid) {
+                Some(mut slot) => {
+                    // The opened check at the top read a clone, so two concurrent
+                    // Tlopen on this fid can both reach here; re-check under the
+                    // shard lock or both install a guard and the lone clunk
+                    // under-counts.
+                    if slot.fid.opened {
+                        return Err(P9Error::FidAlreadyOpen);
+                    }
+                    slot.fid.qid = qid;
+                    slot.fid.opened = true;
+                    slot.fid.mode = Some(tl.flags);
+                    // Install the guard while still holding the shard (via `slot`)
+                    // so the count and the opened flag land together: a clunk or
+                    // close_all blocks on the shard and never sees an opened fid
+                    // that isn't yet counted.
+                    slot.handle = Some(self.filesystem.new_open_handle(inode_id));
+                }
+                None => return Err(P9Error::BadFid),
+            }
+            inode
+        };
 
         let qid = inode_to_qid(&inode, inode_id);
-
-        if let Some(mut fid_entry) = self.session.fids.get_mut(&tl.fid) {
-            fid_entry.qid = qid.clone();
-            fid_entry.opened = true;
-            fid_entry.mode = Some(tl.flags);
-        }
 
         Ok(Message::Rlopen(Rlopen {
             qid,
@@ -682,21 +740,54 @@ impl NinePHandler {
             return Err(P9Error::FidInUse);
         }
 
-        let inode = self.filesystem.inode_store.get(src_fid.inode_id).await?;
-        let qid = inode_to_qid(&inode, src_fid.inode_id);
-
-        self.session.fids.insert(
-            tl.newfid,
-            Fid {
+        // Liveness check + handle increment under the inode lock (see lopen).
+        // The new fid is inserted as opened in the same critical section so the
+        // count and the opened fid become visible together.
+        let inode = {
+            let _guard = self.filesystem.lock_manager.acquire(src_fid.inode_id).await;
+            let inode = self.filesystem.inode_store.get(src_fid.inode_id).await?;
+            let qid = inode_to_qid(&inode, src_fid.inode_id);
+            let new_fid = Fid {
                 path: src_fid.path.clone(),
                 inode_id: src_fid.inode_id,
                 root: src_fid.root,
-                qid: qid.clone(),
+                qid,
                 opened: true,
                 mode: Some(tl.flags),
                 creds: src_fid.creds,
-            },
-        );
+            };
+            // Install the guard under the entry's shard lock (atomic vs clunk,
+            // as in lopen), and only after the error checks so a rejected open
+            // doesn't transiently bump the count.
+            match self.session.fids.entry(tl.newfid) {
+                Entry::Vacant(v) => {
+                    let handle = self.filesystem.new_open_handle(src_fid.inode_id);
+                    v.insert(FidSlot {
+                        fid: new_fid,
+                        handle: Some(handle),
+                        lock_guard: None,
+                    });
+                }
+                Entry::Occupied(mut o) => {
+                    if tl.newfid != tl.fid {
+                        return Err(P9Error::FidInUse);
+                    }
+                    if o.get().fid.opened {
+                        return Err(P9Error::FidAlreadyOpen);
+                    }
+                    // In-place open: replace the fid data and add the handle
+                    // guard, but keep any lock_guard — a lock taken while the fid
+                    // was unopened must survive being opened.
+                    let handle = self.filesystem.new_open_handle(src_fid.inode_id);
+                    let slot = o.get_mut();
+                    slot.fid = new_fid;
+                    slot.handle = Some(handle);
+                }
+            }
+            inode
+        };
+
+        let qid = inode_to_qid(&inode, src_fid.inode_id);
 
         Ok(Message::Rlopenat(Rlopenat {
             qid,
@@ -705,12 +796,22 @@ impl NinePHandler {
     }
 
     async fn clunk(&self, tc: Tclunk) -> Message {
-        if let Some((_, fid_entry)) = self.session.fids.remove(&tc.fid) {
-            self.lock_manager
-                .unlock_range(fid_entry.inode_id, tc.fid, 0, 0, self.handler_id)
-                .await;
+        if let Some((_, slot)) = self.session.fids.remove(&tc.fid) {
+            // Dropping the slot releases its handle count (enqueuing reclaim if it
+            // was the last) and its byte-range locks. `remove` returns the slot to
+            // exactly one caller, so a racing clunk/close_all can't double-release.
+            drop(slot);
         }
         Message::Rclunk(Rclunk)
+    }
+
+    /// Drop every fid in the session, releasing their handle counts and locks.
+    /// Used by Tversion (which implicitly clunks all fids) and by teardown.
+    pub fn close_all_open_handles(&self) {
+        // Each cleared slot's guards release on drop; `remove` vs this `clear` is
+        // still single-winner per fid, so no double-release. A fid an in-flight
+        // open inserts after the clear is released when the table itself drops.
+        self.session.fids.clear();
     }
 
     /// At the attach root of an aname-rooted session, rewrite the synthesized
@@ -877,12 +978,27 @@ impl NinePHandler {
 
         let qid = attrs_to_qid(&post_attr, child_id);
 
-        let mut fid_entry = self.session.fids.get_mut(&tc.fid).ok_or(P9Error::BadFid)?;
-        fid_entry.path.push(Bytes::from(tc.name.data));
-        fid_entry.inode_id = child_id;
-        fid_entry.qid = qid.clone();
-        fid_entry.opened = true;
-        fid_entry.mode = Some(tc.flags);
+        // Move the parent fid onto the new child and install its handle guard,
+        // under the child inode lock so the increment is ordered against a
+        // concurrent remove/rename of the just-created file (as in lopen).
+        {
+            let _guard = self.filesystem.lock_manager.acquire(child_id).await;
+            let mut slot = self.session.fids.get_mut(&tc.fid).ok_or(P9Error::BadFid)?;
+            // Re-check opened (the check above read a clone): a concurrent Tlcreate
+            // on this fid must not also install a guard. A child created by a loser
+            // is harmless — it has a name and nlink 1, like any other file.
+            if slot.fid.opened {
+                return Err(P9Error::FidAlreadyOpen);
+            }
+            slot.fid.path.push(Bytes::from(tc.name.data));
+            slot.fid.inode_id = child_id;
+            slot.fid.qid = qid.clone();
+            slot.fid.opened = true;
+            slot.fid.mode = Some(tc.flags);
+            // Install the guard while `slot` (the shard lock) is still held, so
+            // the count and the opened fid are visible atomically (see lopen).
+            slot.handle = Some(self.filesystem.new_open_handle(child_id));
+        }
 
         Ok(Message::Rlcreate(Rlcreate {
             qid,
@@ -906,9 +1022,11 @@ impl NinePHandler {
 
         let mut path = parent_fid.path.clone();
         path.push(Bytes::from(tc.name.data));
-        self.session.fids.insert(
-            tc.newfid,
-            Fid {
+        // Insert the opened newfid and bump the child's open-handle count under
+        // the child inode lock (uniform with lopen/lopenat).
+        {
+            let _guard = self.filesystem.lock_manager.acquire(child_id).await;
+            let new_fid = Fid {
                 path,
                 inode_id: child_id,
                 root: parent_fid.root,
@@ -916,8 +1034,35 @@ impl NinePHandler {
                 opened: true,
                 mode: Some(tc.flags),
                 creds: parent_fid.creds,
-            },
-        );
+            };
+            // Atomic check-and-insert (see lopenat): single-winner so concurrent
+            // Tlcreateattr with the same newfid cannot double-count the handle.
+            // Install the guard under the entry's shard lock (see lopen).
+            match self.session.fids.entry(tc.newfid) {
+                Entry::Vacant(v) => {
+                    let handle = self.filesystem.new_open_handle(child_id);
+                    v.insert(FidSlot {
+                        fid: new_fid,
+                        handle: Some(handle),
+                        lock_guard: None,
+                    });
+                }
+                Entry::Occupied(mut o) => {
+                    if tc.newfid != tc.dfid {
+                        return Err(P9Error::FidInUse);
+                    }
+                    if o.get().fid.opened {
+                        return Err(P9Error::FidAlreadyOpen);
+                    }
+                    // In-place: update fid data + install the handle guard, but
+                    // PRESERVE any lock_guard (see lopenat).
+                    let handle = self.filesystem.new_open_handle(child_id);
+                    let slot = o.get_mut();
+                    slot.fid = new_fid;
+                    slot.handle = Some(handle);
+                }
+            }
+        }
 
         Ok(Message::Rlcreateattr(Rlcreateattr {
             iounit: self.iounit(),
@@ -1363,14 +1508,28 @@ impl NinePHandler {
         let fid = self.get_fid(tl.fid)?;
 
         if matches!(tl.lock_type, LockType::Unlock) {
-            self.lock_manager
-                .unlock_range(fid.inode_id, tl.fid, tl.start, tl.length, self.handler_id)
-                .await;
+            self.lock_manager.unlock_range(
+                fid.inode_id,
+                tl.fid,
+                tl.start,
+                tl.length,
+                self.handler_id,
+            );
 
             return Ok(Message::Rlock(Rlock {
                 status: LockStatus::Success,
             }));
         }
+
+        // Register the lock and install its guard while holding the fid's shard
+        // lock, so a concurrent clunk/close_all/Tversion can't drop the slot in
+        // between and strand a registered-but-unguarded lock — which, since
+        // Tversion doesn't sweep the manager, would leak for the whole connection.
+        // (Same atomic-install discipline as lopen's handle guard.)
+        let mut slot = match self.session.fids.get_mut(&tl.fid) {
+            Some(slot) => slot,
+            None => return Err(P9Error::BadFid),
+        };
 
         let new_lock = FileLock {
             lock_type: tl.lock_type,
@@ -1379,16 +1538,15 @@ impl NinePHandler {
             proc_id: tl.proc_id,
             client_id: tl.client_id.data.clone(),
             fid: tl.fid,
-            inode_id: fid.inode_id,
+            inode_id: slot.fid.inode_id,
         };
 
         if self
             .lock_manager
             .try_add_lock(self.handler_id, new_lock)
-            .await
             .is_none()
         {
-            debug!("Lock conflict on inode {}", fid.inode_id);
+            debug!("Lock conflict on inode {}", slot.fid.inode_id);
             if (tl.flags & P9_LOCK_FLAGS_BLOCK) != 0 {
                 return Ok(Message::Rlock(Rlock {
                     status: LockStatus::Blocked,
@@ -1396,6 +1554,19 @@ impl NinePHandler {
             } else {
                 return Err(P9Error::LockConflict);
             }
+        }
+
+        #[cfg(feature = "failpoints")]
+        fail_point!(fp::LOCK_AFTER_REGISTER_BEFORE_GUARD);
+
+        // Still under the shard lock. The guard releases by (session, fid) on any
+        // inode, so one per fid is enough.
+        if slot.lock_guard.is_none() {
+            slot.lock_guard = Some(LockGuard::new(
+                self.lock_manager.clone(),
+                self.handler_id,
+                tl.fid,
+            ));
         }
 
         Ok(Message::Rlock(Rlock {
@@ -1416,10 +1587,9 @@ impl NinePHandler {
             inode_id: fid.inode_id,
         };
 
-        if let Some(conflicting_lock) = self
-            .lock_manager
-            .check_would_block(fid.inode_id, &test_lock, self.handler_id)
-            .await
+        if let Some(conflicting_lock) =
+            self.lock_manager
+                .check_would_block(fid.inode_id, &test_lock, self.handler_id)
         {
             Ok(Message::Rgetlock(Rgetlock {
                 lock_type: conflicting_lock.lock_type,
@@ -2185,5 +2355,1182 @@ mod tests {
             }
             _ => panic!("Expected Rreaddir"),
         };
+    }
+
+    #[tokio::test]
+    async fn test_open_unlink_read_after_unlink_via_9p() {
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let lock_manager = Arc::new(FileLockManager::new());
+        let handler = NinePHandler::new(fs.clone(), lock_manager);
+
+        // Tversion + Tattach (root fid 1).
+        handler
+            .handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"test".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+
+        // Clone root onto fid 2 and create + open file "a" (fid 2 is now open).
+        handler
+            .handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 2,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        let create_resp = handler
+            .handle_message(
+                3,
+                Message::Tlcreate(Tlcreate {
+                    fid: 2,
+                    name: P9String::new(b"a".to_vec()),
+                    flags: 0x8002, // O_RDWR | O_CREAT
+                    mode: 0o644,
+                    gid: 1000,
+                }),
+            )
+            .await;
+        assert!(matches!(create_resp.body, Message::Rlcreate(_)));
+
+        let data = b"open-unlink via 9p";
+        handler
+            .handle_message(
+                4,
+                Message::Twrite(Twrite {
+                    fid: 2,
+                    offset: 0,
+                    count: data.len() as u32,
+                    data: DekuBytes::from(data.to_vec()),
+                }),
+            )
+            .await;
+
+        // The created file is now open on fid 2, holding an open handle.
+        let file_id = fs.lookup(&test_creds(), 0, b"a").await.unwrap();
+        assert_eq!(fs.open_handle_count(file_id), 1);
+
+        // `rm a`: Tunlinkat from the root fid. Defers because fid 2 is open.
+        let unlink_resp = handler
+            .handle_message(
+                5,
+                Message::Tunlinkat(Tunlinkat {
+                    dirfid: 1,
+                    name: P9String::new(b"a".to_vec()),
+                    flags: 0,
+                }),
+            )
+            .await;
+        assert!(matches!(unlink_resp.body, Message::Runlinkat(_)));
+        // Name is gone; inode is kept alive for the open fid.
+        assert!(matches!(
+            fs.lookup(&test_creds(), 0, b"a").await,
+            Err(FsError::NotFound)
+        ));
+        assert!(fs.inode_store.get(file_id).await.is_ok());
+
+        // `cat <&3`: Tread on the still-open fid 2 must succeed (the bug).
+        let read_resp = handler
+            .handle_message(
+                6,
+                Message::Tread(Tread {
+                    fid: 2,
+                    offset: 0,
+                    count: data.len() as u32,
+                }),
+            )
+            .await;
+        match read_resp.body {
+            Message::Rread(r) => assert_eq!(r.data.as_ref(), data),
+            other => panic!("expected Rread with data, got {other:?}"),
+        }
+
+        // Closing fd 3 (Tclunk fid 2) is the last handle: reclaim now.
+        let clunk_resp = handler
+            .handle_message(7, Message::Tclunk(Tclunk { fid: 2 }))
+            .await;
+        assert!(matches!(clunk_resp.body, Message::Rclunk(_)));
+        // The clunk dropped the fid slot, whose RAII guard released the last
+        // handle (count 0) and enqueued the inode for the reclaim drainer. This
+        // fs has no drainer running, so drive the same reclaim path the drainer
+        // would (lock + recheck count==0 + reclaim) and confirm the inode is gone.
+        assert_eq!(fs.open_handle_count(file_id), 0);
+        fs.reclaim_if_unreferenced(file_id).await;
+        assert!(matches!(
+            fs.inode_store.get(file_id).await,
+            Err(FsError::NotFound)
+        ));
+    }
+
+    // With the drainer running, the last clunk of an open-unlinked inode must
+    // reclaim it asynchronously, with no explicit reclaim call — exercising the
+    // whole guard-drop → enqueue → drainer path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_reclaim_drainer_reclaims_after_last_clunk() {
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        fs.start_reclaim_drainer();
+        let handler = Arc::new(NinePHandler::new(
+            fs.clone(),
+            Arc::new(FileLockManager::new()),
+        ));
+        handler
+            .handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"test".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+        // create + open "a" on fid 2
+        handler
+            .handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 2,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                3,
+                Message::Tlcreate(Tlcreate {
+                    fid: 2,
+                    name: P9String::new(b"a".to_vec()),
+                    flags: 0x8002,
+                    mode: 0o644,
+                    gid: 1000,
+                }),
+            )
+            .await;
+        let file_id = fs.lookup(&test_creds(), 0, b"a").await.unwrap();
+        // unlink (defers: fid 2 holds it open)
+        handler
+            .handle_message(
+                4,
+                Message::Tunlinkat(Tunlinkat {
+                    dirfid: 1,
+                    name: P9String::new(b"a".to_vec()),
+                    flags: 0,
+                }),
+            )
+            .await;
+        assert!(fs.inode_store.get(file_id).await.is_ok());
+
+        // Last clunk: the guard drop enqueues the inode; the drainer reclaims it.
+        handler
+            .handle_message(5, Message::Tclunk(Tclunk { fid: 2 }))
+            .await;
+
+        let mut gone = false;
+        for _ in 0..250 {
+            if fs.inode_store.get(file_id).await.is_err() {
+                gone = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            gone,
+            "reclaim drainer did not reclaim the open-unlinked inode after the last clunk"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_lopen_same_fid_counts_once() {
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let lock_manager = Arc::new(FileLockManager::new());
+        let handler = Arc::new(NinePHandler::new(fs.clone(), lock_manager));
+
+        handler
+            .handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"test".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+        // Create "a" (fid 2 via lcreate), then clunk so it exists with 0 handles.
+        handler
+            .handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 2,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                3,
+                Message::Tlcreate(Tlcreate {
+                    fid: 2,
+                    name: P9String::new(b"a".to_vec()),
+                    flags: 0x8002,
+                    mode: 0o644,
+                    gid: 1000,
+                }),
+            )
+            .await;
+        handler
+            .handle_message(4, Message::Tclunk(Tclunk { fid: 2 }))
+            .await;
+        let file_id = fs.lookup(&test_creds(), 0, b"a").await.unwrap();
+        assert_eq!(fs.open_handle_count(file_id), 0);
+
+        for round in 0..200u32 {
+            // Walk a fresh, unopened fid 3 to "a".
+            handler
+                .handle_message(
+                    10,
+                    Message::Twalk(Twalk {
+                        fid: 1,
+                        newfid: 3,
+                        nwname: 1,
+                        wnames: vec![P9String::new(b"a".to_vec())],
+                    }),
+                )
+                .await;
+
+            let h1 = handler.clone();
+            let h2 = handler.clone();
+            let t1 = tokio::spawn(async move {
+                h1.handle_message(11, Message::Tlopen(Tlopen { fid: 3, flags: 0 }))
+                    .await
+            });
+            let t2 = tokio::spawn(async move {
+                h2.handle_message(12, Message::Tlopen(Tlopen { fid: 3, flags: 0 }))
+                    .await
+            });
+            let r1 = t1.await.unwrap();
+            let r2 = t2.await.unwrap();
+
+            let successes = matches!(r1.body, Message::Rlopen(_)) as u8
+                + matches!(r2.body, Message::Rlopen(_)) as u8;
+            assert_eq!(
+                successes, 1,
+                "round {round}: exactly one Tlopen should win, got {:?} / {:?}",
+                r1.body, r2.body
+            );
+            assert_eq!(
+                fs.open_handle_count(file_id),
+                1,
+                "round {round}: handle was double-counted"
+            );
+
+            handler
+                .handle_message(13, Message::Tclunk(Tclunk { fid: 3 }))
+                .await;
+            assert_eq!(
+                fs.open_handle_count(file_id),
+                0,
+                "round {round}: handle not released"
+            );
+        }
+    }
+
+    // Teardown (close_all) racing a Tclunk of the same fid must release its
+    // handle exactly once. A double release would drop the count below the true
+    // live count and reclaim an inode another session still holds open.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_teardown_vs_clunk_releases_handle_once() {
+        for round in 0..300u32 {
+            let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+            let lock_manager = Arc::new(FileLockManager::new());
+            let handler = Arc::new(NinePHandler::new(fs.clone(), lock_manager));
+
+            handler
+                .handle_message(
+                    0,
+                    Message::Tversion(Tversion {
+                        msize: DEFAULT_MSIZE,
+                        version: P9String::new(VERSION_9P2000L.to_vec()),
+                    }),
+                )
+                .await;
+            handler
+                .handle_message(
+                    1,
+                    Message::Tattach(Tattach {
+                        fid: 1,
+                        afid: u32::MAX,
+                        uname: P9String::new(b"test".to_vec()),
+                        aname: P9String::new(Vec::new()),
+                        n_uname: 1000,
+                    }),
+                )
+                .await;
+            // Create + open "a" on fid 2 (this session's handle) -> count 1.
+            handler
+                .handle_message(
+                    2,
+                    Message::Twalk(Twalk {
+                        fid: 1,
+                        newfid: 2,
+                        nwname: 0,
+                        wnames: vec![],
+                    }),
+                )
+                .await;
+            handler
+                .handle_message(
+                    3,
+                    Message::Tlcreate(Tlcreate {
+                        fid: 2,
+                        name: P9String::new(b"a".to_vec()),
+                        flags: 0x8002,
+                        mode: 0o644,
+                        gid: 1000,
+                    }),
+                )
+                .await;
+            let file_id = fs.lookup(&test_creds(), 0, b"a").await.unwrap();
+
+            // Simulate a SECOND session also holding "a" open (not torn down here).
+            fs.open_handle_inc(file_id);
+
+            // `rm a` while open -> deferred (orphan); count still 2.
+            handler
+                .handle_message(
+                    4,
+                    Message::Tunlinkat(Tunlinkat {
+                        dirfid: 1,
+                        name: P9String::new(b"a".to_vec()),
+                        flags: 0,
+                    }),
+                )
+                .await;
+            assert_eq!(fs.open_handle_count(file_id), 2);
+
+            // RACE: this session disconnects (close_all) while a Tclunk of fid 2 is
+            // in flight on the same session.
+            let h1 = handler.clone();
+            let h2 = handler.clone();
+            let t1 = tokio::spawn(async move { h1.close_all_open_handles() });
+            let t2 = tokio::spawn(async move {
+                h2.handle_message(5, Message::Tclunk(Tclunk { fid: 2 }))
+                    .await
+            });
+            t1.await.unwrap();
+            t2.await.unwrap();
+
+            // This session's single handle was released exactly once (2 -> 1); the
+            // other session's handle must keep "a" alive (NOT reclaimed).
+            assert_eq!(
+                fs.open_handle_count(file_id),
+                1,
+                "round {round}: fid double-released, count dropped below live"
+            );
+            assert!(
+                fs.inode_store.get(file_id).await.is_ok(),
+                "round {round}: inode reclaimed while another session still holds it"
+            );
+
+            // The other session finally closes -> reclaim.
+            fs.handle_closed(file_id).await;
+            assert!(matches!(
+                fs.inode_store.get(file_id).await,
+                Err(FsError::NotFound)
+            ));
+        }
+    }
+
+    // Walking a fid in place (newfid == fid, non-empty wnames) overwrites its
+    // slot; if the fid was an opened directory, the overwrite must still release
+    // its handle count. Note a pure clone (empty wnames) is a no-op, so the walk
+    // target has to be a real child.
+    #[tokio::test]
+    async fn test_walk_in_place_over_open_dir_leaks_handle() {
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let lock_manager = Arc::new(FileLockManager::new());
+        let handler = Arc::new(NinePHandler::new(fs.clone(), lock_manager));
+        handler
+            .handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"test".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+        // Create a child "x" so the in-place walk has a target.
+        handler
+            .handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 2,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                3,
+                Message::Tlcreate(Tlcreate {
+                    fid: 2,
+                    name: P9String::new(b"x".to_vec()),
+                    flags: 0x8002,
+                    mode: 0o644,
+                    gid: 1000,
+                }),
+            )
+            .await;
+        handler
+            .handle_message(4, Message::Tclunk(Tclunk { fid: 2 }))
+            .await;
+
+        // Open a *directory* fid on the root (fid 10).
+        handler
+            .handle_message(
+                5,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 10,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(6, Message::Tlopen(Tlopen { fid: 10, flags: 0 }))
+            .await;
+        assert_eq!(
+            fs.open_handle_count(0),
+            1,
+            "root dir should be open on fid 10"
+        );
+
+        // Walk fid 10 in place to child "x": overwrites the opened dir fid.
+        let resp = handler
+            .handle_message(
+                7,
+                Message::Twalk(Twalk {
+                    fid: 10,
+                    newfid: 10,
+                    nwname: 1,
+                    wnames: vec![P9String::new(b"x".to_vec())],
+                }),
+            )
+            .await;
+        assert!(
+            matches!(resp.body, Message::Rwalk(_)),
+            "in-place walk must succeed to exercise the overwrite, got {:?}",
+            resp.body
+        );
+
+        // Clunk the (now opened:false) fid 10.
+        handler
+            .handle_message(8, Message::Tclunk(Tclunk { fid: 10 }))
+            .await;
+
+        assert_eq!(
+            fs.open_handle_count(0),
+            0,
+            "N2: walk-in-place over an open dir fid stranded the open-handle count"
+        );
+    }
+
+    // A fid holding a POSIX lock, then walked in place (overwriting its slot),
+    // must have its lock released. ZeroFS doesn't enforce 9P's "don't walk an
+    // open fid" rule, so this is reachable.
+    #[tokio::test]
+    async fn test_walk_in_place_over_locked_dir_releases_lock() {
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let lock_manager = Arc::new(FileLockManager::new());
+        let handler = Arc::new(NinePHandler::new(fs.clone(), lock_manager.clone()));
+        handler
+            .handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"test".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+        // child "x" for the in-place walk target
+        handler
+            .handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 2,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                3,
+                Message::Tlcreate(Tlcreate {
+                    fid: 2,
+                    name: P9String::new(b"x".to_vec()),
+                    flags: 0x8002,
+                    mode: 0o644,
+                    gid: 1000,
+                }),
+            )
+            .await;
+        handler
+            .handle_message(4, Message::Tclunk(Tclunk { fid: 2 }))
+            .await;
+        // open root dir on fid 10, then write-lock it
+        handler
+            .handle_message(
+                5,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 10,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(6, Message::Tlopen(Tlopen { fid: 10, flags: 0 }))
+            .await;
+        handler
+            .handle_message(
+                7,
+                Message::Tlock(Tlock {
+                    fid: 10,
+                    lock_type: LockType::WriteLock,
+                    flags: 0,
+                    start: 0,
+                    length: 0,
+                    proc_id: 1,
+                    client_id: P9String::new(b"c".to_vec()),
+                }),
+            )
+            .await;
+        assert!(
+            lock_manager.session_has_locks(handler.handler_id),
+            "write lock should be held on fid 10"
+        );
+
+        // Walk fid 10 in place to "x": overwrites the locked dir fid's slot.
+        let resp = handler
+            .handle_message(
+                8,
+                Message::Twalk(Twalk {
+                    fid: 10,
+                    newfid: 10,
+                    nwname: 1,
+                    wnames: vec![P9String::new(b"x".to_vec())],
+                }),
+            )
+            .await;
+        assert!(matches!(resp.body, Message::Rwalk(_)));
+
+        assert!(
+            !lock_manager.session_has_locks(handler.handler_id),
+            "walk-in-place over a locked fid leaked the byte-range lock"
+        );
+    }
+
+    // Tversion resets the session, so it must release the session's byte-range
+    // locks along with its fids.
+    #[tokio::test]
+    async fn test_tversion_releases_byte_range_locks() {
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let lock_manager = Arc::new(FileLockManager::new());
+        let handler = Arc::new(NinePHandler::new(fs.clone(), lock_manager.clone()));
+        handler
+            .handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"test".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 10,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(3, Message::Tlopen(Tlopen { fid: 10, flags: 0 }))
+            .await;
+        handler
+            .handle_message(
+                4,
+                Message::Tlock(Tlock {
+                    fid: 10,
+                    lock_type: LockType::WriteLock,
+                    flags: 0,
+                    start: 0,
+                    length: 0,
+                    proc_id: 1,
+                    client_id: P9String::new(b"c".to_vec()),
+                }),
+            )
+            .await;
+        assert!(lock_manager.session_has_locks(handler.handler_id));
+
+        // Tversion resets the session.
+        handler
+            .handle_message(
+                5,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+
+        assert!(
+            !lock_manager.session_has_locks(handler.handler_id),
+            "Tversion left the session's byte-range locks dangling"
+        );
+    }
+
+    // A failpoint pauses lock() after it registers the lock but before the guard
+    // is installed, then a concurrent Tversion clears the fid table. Unless the
+    // register and guard install are atomic (the slot held across both), Tversion
+    // drops the guardless slot and strands the lock — which, with no in-session
+    // backstop, leaks for the whole connection. Run with `--features failpoints`.
+    #[cfg(feature = "failpoints")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_lock_register_guard_atomic_vs_tversion() {
+        let _scenario = fail::FailScenario::setup();
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let lock_manager = Arc::new(FileLockManager::new());
+        let handler = Arc::new(NinePHandler::new(fs.clone(), lock_manager.clone()));
+        handler
+            .handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"t".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+        handler
+            .handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 10,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+        handler
+            .handle_message(3, Message::Tlopen(Tlopen { fid: 10, flags: 0 }))
+            .await;
+
+        // Pause lock() after it registers the lock, before installing the guard.
+        fail::cfg(fp::LOCK_AFTER_REGISTER_BEFORE_GUARD, "pause").unwrap();
+
+        let h1 = handler.clone();
+        let lock_task = tokio::spawn(async move {
+            h1.handle_message(
+                4,
+                Message::Tlock(Tlock {
+                    fid: 10,
+                    lock_type: LockType::WriteLock,
+                    flags: 0,
+                    start: 0,
+                    length: 0,
+                    proc_id: 1,
+                    client_id: P9String::new(b"c".to_vec()),
+                }),
+            )
+            .await
+        });
+
+        // Wait until the lock registers; the lock task is now paused at the
+        // failpoint, holding the fid shard if the install is atomic.
+        let mut registered = false;
+        for _ in 0..400 {
+            if lock_manager.session_has_locks(handler.handler_id()) {
+                registered = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(registered, "lock task did not register/pause in time");
+
+        // Concurrent Tversion reset. Atomic fix: blocks on the held shard.
+        // Buggy: clears the guardless slot freely.
+        let h2 = handler.clone();
+        let version_task = tokio::spawn(async move {
+            h2.handle_message(
+                5,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await
+        });
+
+        // Let Tversion run (buggy: clears; atomic: blocks on the shard).
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Resume lock(): install the guard (atomic) or find the slot gone (buggy).
+        fail::cfg(fp::LOCK_AFTER_REGISTER_BEFORE_GUARD, "off").unwrap();
+
+        let _ = lock_task.await;
+        let _ = version_task.await;
+
+        assert!(
+            !lock_manager.session_has_locks(handler.handler_id()),
+            "Tlock racing Tversion stranded a phantom byte-range lock (register+guard not atomic)"
+        );
+    }
+
+    // Teardown (close_all) racing an in-flight open that inserts a fresh fid
+    // (lopenat). The late fid's handle guard must still be released — if not at
+    // the clear, then when the session table drops. 300 rounds on a shared fs;
+    // any stranded count survives to the final assert.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_close_all_vs_inflight_open_no_leak() {
+        let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+        let lock_manager = Arc::new(FileLockManager::new());
+
+        // Create "a" once (persists on the shared fs across rounds).
+        {
+            let h = Arc::new(NinePHandler::new(fs.clone(), lock_manager.clone()));
+            h.handle_message(
+                0,
+                Message::Tversion(Tversion {
+                    msize: DEFAULT_MSIZE,
+                    version: P9String::new(VERSION_9P2000L.to_vec()),
+                }),
+            )
+            .await;
+            h.handle_message(
+                1,
+                Message::Tattach(Tattach {
+                    fid: 1,
+                    afid: u32::MAX,
+                    uname: P9String::new(b"t".to_vec()),
+                    aname: P9String::new(Vec::new()),
+                    n_uname: 1000,
+                }),
+            )
+            .await;
+            h.handle_message(
+                2,
+                Message::Twalk(Twalk {
+                    fid: 1,
+                    newfid: 2,
+                    nwname: 0,
+                    wnames: vec![],
+                }),
+            )
+            .await;
+            h.handle_message(
+                3,
+                Message::Tlcreate(Tlcreate {
+                    fid: 2,
+                    name: P9String::new(b"a".to_vec()),
+                    flags: 0x8002,
+                    mode: 0o644,
+                    gid: 1000,
+                }),
+            )
+            .await;
+            h.handle_message(4, Message::Tclunk(Tclunk { fid: 2 }))
+                .await;
+        }
+
+        for round in 0..300u16 {
+            let handler = Arc::new(NinePHandler::new(fs.clone(), lock_manager.clone()));
+            handler
+                .handle_message(
+                    0,
+                    Message::Tversion(Tversion {
+                        msize: DEFAULT_MSIZE,
+                        version: P9String::new(VERSION_9P2000L.to_vec()),
+                    }),
+                )
+                .await;
+            handler
+                .handle_message(
+                    1,
+                    Message::Tattach(Tattach {
+                        fid: 1,
+                        afid: u32::MAX,
+                        uname: P9String::new(b"t".to_vec()),
+                        aname: P9String::new(Vec::new()),
+                        n_uname: 1000,
+                    }),
+                )
+                .await;
+            // fid 5 -> "a" (unopened): the source for the in-flight open.
+            handler
+                .handle_message(
+                    2,
+                    Message::Twalk(Twalk {
+                        fid: 1,
+                        newfid: 5,
+                        nwname: 1,
+                        wnames: vec![P9String::new(b"a".to_vec())],
+                    }),
+                )
+                .await;
+
+            let h1 = handler.clone();
+            let h2 = handler.clone();
+            // RACE: teardown vs an in-flight lopenat that inserts fid 6 (opened).
+            let t1 = tokio::spawn(async move { h1.close_all_open_handles() });
+            let t2 = tokio::spawn(async move {
+                h2.handle_message(
+                    round,
+                    Message::Tlopenat(Tlopenat {
+                        fid: 5,
+                        newfid: 6,
+                        flags: 0,
+                    }),
+                )
+                .await
+            });
+            let _ = t1.await;
+            let _ = t2.await;
+            // Dropping the last handler ref drops the session table; a fid the
+            // open inserted after the clear releases its guard here.
+            drop(handler);
+        }
+
+        let leaked: Vec<(u64, u64)> = fs
+            .open_handles
+            .iter()
+            .map(|e| (*e.key(), *e.value()))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "close_all vs in-flight open stranded handle counts: {leaked:?}"
+        );
+    }
+
+    // Many concurrent sessions, each with several worker tasks, thrash the
+    // fid/handle lifecycle over a tiny shared namespace. Invariant: once every
+    // session has torn down, no open-handle count may remain — a leftover entry
+    // is a leak, whatever path caused it. The seed is in the failure message.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stress_handle_lifecycle_no_leak() {
+        fn xs(s: &mut u64) -> u64 {
+            let mut x = *s;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            *s = x;
+            x
+        }
+        const SESSIONS: u64 = 4;
+        const TASKS: u64 = 3;
+        const ITERS: u64 = 120;
+        let names: [&[u8]; 3] = [b"a", b"b", b"c"];
+
+        for seed in 1..=8u64 {
+            let fs = Arc::new(ZeroFS::new_in_memory().await.unwrap());
+            let lock_manager = Arc::new(FileLockManager::new());
+
+            let mut sessions = Vec::new();
+            for s in 0..SESSIONS {
+                let fs = fs.clone();
+                let lm = lock_manager.clone();
+                sessions.push(tokio::spawn(async move {
+                    let handler = Arc::new(NinePHandler::new(fs, lm));
+                    handler
+                        .handle_message(
+                            0,
+                            Message::Tversion(Tversion {
+                                msize: DEFAULT_MSIZE,
+                                version: P9String::new(VERSION_9P2000L.to_vec()),
+                            }),
+                        )
+                        .await;
+                    handler
+                        .handle_message(
+                            1,
+                            Message::Tattach(Tattach {
+                                fid: 1,
+                                afid: u32::MAX,
+                                uname: P9String::new(b"t".to_vec()),
+                                aname: P9String::new(Vec::new()),
+                                n_uname: 1000,
+                            }),
+                        )
+                        .await;
+
+                    let mut workers = Vec::new();
+                    for t in 0..TASKS {
+                        let handler = handler.clone();
+                        let mut rng = (seed ^ (s << 8) ^ (t << 4)) | 1;
+                        let base_fid = 10 + (t as u32) * 10;
+                        workers.push(tokio::spawn(async move {
+                            for i in 0..ITERS {
+                                let r = xs(&mut rng);
+                                let fid = base_fid + ((r >> 3) as u32) % 4;
+                                let name = names[(r >> 20) as usize % names.len()].to_vec();
+                                let tag = (2000 + i) as u16;
+                                match r % 8 {
+                                    0 => {
+                                        // create + open on `fid`
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Twalk(Twalk {
+                                                    fid: 1,
+                                                    newfid: fid,
+                                                    nwname: 0,
+                                                    wnames: vec![],
+                                                }),
+                                            )
+                                            .await;
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Tlcreate(Tlcreate {
+                                                    fid,
+                                                    name: P9String::new(name),
+                                                    flags: 0x8002,
+                                                    mode: 0o644,
+                                                    gid: 1000,
+                                                }),
+                                            )
+                                            .await;
+                                    }
+                                    1 => {
+                                        // walk to name, then open
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Twalk(Twalk {
+                                                    fid: 1,
+                                                    newfid: fid,
+                                                    nwname: 1,
+                                                    wnames: vec![P9String::new(name)],
+                                                }),
+                                            )
+                                            .await;
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Tlopen(Tlopen { fid, flags: 0 }),
+                                            )
+                                            .await;
+                                    }
+                                    2 => {
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Tread(Tread {
+                                                    fid,
+                                                    offset: 0,
+                                                    count: 32,
+                                                }),
+                                            )
+                                            .await;
+                                    }
+                                    3 => {
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Twrite(Twrite {
+                                                    fid,
+                                                    offset: 0,
+                                                    count: 2,
+                                                    data: DekuBytes::from(vec![1u8, 2u8]),
+                                                }),
+                                            )
+                                            .await;
+                                    }
+                                    4 => {
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Tunlinkat(Tunlinkat {
+                                                    dirfid: 1,
+                                                    name: P9String::new(name),
+                                                    flags: 0,
+                                                }),
+                                            )
+                                            .await;
+                                    }
+                                    5 => {
+                                        // open a directory fid (clone root, then open) so
+                                        // op 6's in-place walk has an opened dir to overwrite
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Twalk(Twalk {
+                                                    fid: 1,
+                                                    newfid: fid,
+                                                    nwname: 0,
+                                                    wnames: vec![],
+                                                }),
+                                            )
+                                            .await;
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Tlopen(Tlopen { fid, flags: 0 }),
+                                            )
+                                            .await;
+                                    }
+                                    6 => {
+                                        // walk `fid` in place to a child: if it's an opened
+                                        // dir this overwrites the slot, which must release
+                                        // the handle (empty wnames would be a no-op)
+                                        handler
+                                            .handle_message(
+                                                tag,
+                                                Message::Twalk(Twalk {
+                                                    fid,
+                                                    newfid: fid,
+                                                    nwname: 1,
+                                                    wnames: vec![P9String::new(name)],
+                                                }),
+                                            )
+                                            .await;
+                                    }
+                                    _ => {
+                                        handler
+                                            .handle_message(tag, Message::Tclunk(Tclunk { fid }))
+                                            .await;
+                                    }
+                                }
+                            }
+                        }));
+                    }
+                    for w in workers {
+                        let _ = w.await;
+                    }
+                    handler.close_all_open_handles();
+                }));
+            }
+            for sh in sessions {
+                sh.await.unwrap();
+            }
+
+            let leaked: Vec<(u64, u64)> = fs
+                .open_handles
+                .iter()
+                .map(|e| (*e.key(), *e.value()))
+                .collect();
+            assert!(
+                leaked.is_empty(),
+                "seed {seed}: leaked open-handle counts after all sessions closed: {leaked:?}"
+            );
+        }
+    }
+
+    fn test_creds() -> Credentials {
+        Credentials {
+            uid: 1000,
+            gid: 1000,
+            groups: [1000; 16],
+            groups_count: 1,
+        }
     }
 }

--- a/zerofs/src/ninep/lock_manager.rs
+++ b/zerofs/src/ninep/lock_manager.rs
@@ -41,8 +41,10 @@ pub struct FileLockManager {
     locks: Arc<DashMap<LockId, FileLock>>,
     // Counter for generating unique lock IDs
     next_lock_id: Arc<AtomicU64>,
-    // Mutex for atomic lock operations
-    lock_mutex: Arc<tokio::sync::Mutex<()>>,
+    // Serializes lock operations. A std (not tokio) mutex: every critical
+    // section below is await-free DashMap work, and being sync lets LockGuard
+    // release locks from its (sync) Drop.
+    lock_mutex: Arc<std::sync::Mutex<()>>,
 }
 
 impl FileLockManager {
@@ -52,7 +54,7 @@ impl FileLockManager {
             locks_by_session: Arc::new(DashMap::new()),
             locks: Arc::new(DashMap::new()),
             next_lock_id: Arc::new(AtomicU64::new(1)),
-            lock_mutex: Arc::new(tokio::sync::Mutex::new(())),
+            lock_mutex: Arc::new(std::sync::Mutex::new(())),
         }
     }
 
@@ -96,8 +98,8 @@ impl FileLockManager {
     }
 
     /// Attempts to add a lock, returning the lock ID on success or `None` on conflict.
-    pub async fn try_add_lock(&self, session_id: u64, lock: FileLock) -> Option<LockId> {
-        let _guard = self.lock_mutex.lock().await;
+    pub fn try_add_lock(&self, session_id: u64, lock: FileLock) -> Option<LockId> {
+        let _guard = self.lock_mutex.lock().unwrap_or_else(|e| e.into_inner());
 
         // Check for conflicts *before* mutating any state. POSIX requires that a
         // failed lock request leave the caller's existing locks untouched (e.g. a
@@ -132,7 +134,7 @@ impl FileLockManager {
         Some(self.insert_lock(session_id, lock))
     }
 
-    pub async fn unlock_range(
+    pub fn unlock_range(
         &self,
         inode_id: InodeId,
         fid: u32,
@@ -140,7 +142,7 @@ impl FileLockManager {
         length: u64,
         session_id: u64,
     ) -> bool {
-        let _guard = self.lock_mutex.lock().await;
+        let _guard = self.lock_mutex.lock().unwrap_or_else(|e| e.into_inner());
 
         let unlock_end = if length == 0 {
             u64::MAX
@@ -275,13 +277,13 @@ impl FileLockManager {
         false
     }
 
-    pub async fn check_would_block(
+    pub fn check_would_block(
         &self,
         inode_id: InodeId,
         test_lock: &FileLock,
         session_id: u64,
     ) -> Option<FileLock> {
-        let _guard = self.lock_mutex.lock().await;
+        let _guard = self.lock_mutex.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(lock_ids) = self.locks_by_inode.get(&inode_id) {
             for lock_id in lock_ids.iter() {
                 if let Some(existing_lock) = self.locks.get(lock_id) {
@@ -314,8 +316,8 @@ impl FileLockManager {
         None
     }
 
-    pub async fn release_session_locks(&self, session_id: u64) {
-        let _guard = self.lock_mutex.lock().await;
+    pub fn release_session_locks(&self, session_id: u64) {
+        let _guard = self.lock_mutex.lock().unwrap_or_else(|e| e.into_inner());
 
         if let Some((_, lock_ids)) = self.locks_by_session.remove(&session_id) {
             for lock_id in lock_ids {
@@ -327,6 +329,55 @@ impl FileLockManager {
                 }
             }
         }
+    }
+
+    /// Release every lock `fid` holds in `session_id`, on any inode; returns
+    /// whether anything was released. Backs `LockGuard::drop` — keyed by
+    /// (session, fid), not inode, so it covers a fid that was walked to another
+    /// inode while holding locks.
+    pub fn release_fid_locks(&self, session_id: u64, fid: u32) -> bool {
+        let _guard = self.lock_mutex.lock().unwrap_or_else(|e| e.into_inner());
+
+        let to_remove: Vec<LockId> = match self.locks_by_session.get(&session_id) {
+            Some(lock_ids) => lock_ids
+                .iter()
+                .filter(|id| self.locks.get(id).is_some_and(|l| l.fid == fid))
+                .copied()
+                .collect(),
+            None => return false,
+        };
+
+        for lock_id in &to_remove {
+            self.remove_lock(session_id, *lock_id);
+        }
+        !to_remove.is_empty()
+    }
+}
+
+/// Releases all of a fid's byte-range locks on drop. Created on the fid's first
+/// `Tlock` and stored in its session slot, so dropping or overwriting the slot
+/// frees the locks exactly once — the lock counterpart of `OpenHandle`.
+#[derive(Debug)]
+pub struct LockGuard {
+    lock_manager: Arc<FileLockManager>,
+    session_id: u64,
+    fid: u32,
+}
+
+impl LockGuard {
+    pub fn new(lock_manager: Arc<FileLockManager>, session_id: u64, fid: u32) -> Self {
+        Self {
+            lock_manager,
+            session_id,
+            fid,
+        }
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        self.lock_manager
+            .release_fid_locks(self.session_id, self.fid);
     }
 }
 
@@ -357,34 +408,23 @@ mod tests {
         let m = FileLockManager::new();
 
         // Owners 1 and 2 both hold a read lock over [0, 10) — compatible.
-        assert!(
-            m.try_add_lock(1, lock(LockType::ReadLock, 0, 10))
-                .await
-                .is_some()
-        );
-        assert!(
-            m.try_add_lock(2, lock(LockType::ReadLock, 0, 10))
-                .await
-                .is_some()
-        );
+        assert!(m.try_add_lock(1, lock(LockType::ReadLock, 0, 10)).is_some());
+        assert!(m.try_add_lock(2, lock(LockType::ReadLock, 0, 10)).is_some());
 
         // Owner 1 tries to upgrade to a write lock; owner 2's read lock conflicts.
         assert!(
             m.try_add_lock(1, lock(LockType::WriteLock, 0, 10))
-                .await
                 .is_none(),
             "conflicting upgrade must be refused"
         );
 
         // Drop owner 2's lock so only owner 1's (read) lock could remain.
-        m.unlock_range(INODE, 0, 0, 10, 2).await;
+        m.unlock_range(INODE, 0, 0, 10, 2);
 
         // A third owner testing a write lock must still see owner 1's surviving
         // read lock. With the pre-fix behaviour, owner 1's read lock would have
         // been destroyed by the failed upgrade and this would find no conflict.
-        let conflict = m
-            .check_would_block(INODE, &lock(LockType::WriteLock, 0, 10), 3)
-            .await;
+        let conflict = m.check_would_block(INODE, &lock(LockType::WriteLock, 0, 10), 3);
         assert!(
             conflict.is_some(),
             "owner 1's read lock must survive the failed upgrade"

--- a/zerofs/src/ninep/server.rs
+++ b/zerofs/src/ninep/server.rs
@@ -176,9 +176,32 @@ where
         }
     });
 
+    // Release every still-open fid's open-handle count on session teardown.
+    struct HandleReleaseGuard(Option<Arc<NinePHandler>>);
+    impl HandleReleaseGuard {
+        fn disarm(&mut self) -> Option<Arc<NinePHandler>> {
+            self.0.take()
+        }
+    }
+    impl Drop for HandleReleaseGuard {
+        fn drop(&mut self) {
+            if let Some(handler) = self.0.take() {
+                // Backstop for an abnormal exit (the normal path disarms us and
+                // does this itself). Just a synchronous table clear — the slot
+                // guards do the rest on drop.
+                handler.close_all_open_handles();
+            }
+        }
+    }
+    let mut release_guard = HandleReleaseGuard(Some(Arc::clone(&handler)));
+
     let result = handle_client_loop(handler, read_stream, tx, shutdown).await;
 
-    lock_manager.release_session_locks(handler_id).await;
+    if let Some(handler) = release_guard.disarm() {
+        handler.close_all_open_handles();
+    }
+
+    lock_manager.release_session_locks(handler_id);
 
     let _ = writer_task.await;
 

--- a/zerofs/src/rpc/server.rs
+++ b/zerofs/src/rpc/server.rs
@@ -692,6 +692,7 @@ mod tests {
                 .await
                 .unwrap(),
         );
+        fs.start_reclaim_drainer();
         let checkpoint_manager = Arc::new(CheckpointManager::new(
             db_handle,
             db_path,

--- a/zerofs/src/webui.rs
+++ b/zerofs/src/webui.rs
@@ -89,7 +89,11 @@ async fn handle_9p_ws(socket: WebSocket, state: AppState) {
 
     drop(tx);
     let _ = writer.await;
-    state.lock_manager.release_session_locks(handler_id).await;
+    // Same teardown as the TCP/Unix path: release this session's handle counts
+    // and byte-range locks (rather than wait for the last in-flight task to drop
+    // its handler Arc).
+    handler.close_all_open_handles();
+    state.lock_manager.release_session_locks(handler_id);
 }
 
 fn content_type(path: &str) -> &'static str {

--- a/zerofs/tests/failpoints/consistency.rs
+++ b/zerofs/tests/failpoints/consistency.rs
@@ -133,6 +133,12 @@ pub enum ConsistencyError {
         stored_counter: u64,
         max_cookie: u64,
     },
+    /// An open-unlink orphan-set entry survived a clean restart. The startup
+    /// drain reclaims every orphan (no open handle survives a crash), so after
+    /// a restart the set must be empty; a leftover means the drain failed.
+    LeakedOrphan {
+        inode_id: InodeId,
+    },
 }
 
 impl ConsistencyReport {
@@ -303,6 +309,11 @@ impl std::fmt::Display for ConsistencyError {
                 "DIR_COOKIE counter {} for dir {} is not greater than max used cookie {}",
                 stored_counter, dir_id, max_cookie
             ),
+            Self::LeakedOrphan { inode_id } => write!(
+                f,
+                "Orphan-set entry for inode {} survived restart (startup drain did not reclaim it)",
+                inode_id
+            ),
         }
     }
 }
@@ -345,6 +356,11 @@ pub struct ConsistencyChecker<'a> {
     subdir_counts: HashMap<InodeId, u32>,
     tombstone_inodes: HashSet<InodeId>,
     directory_inodes: HashSet<InodeId>,
+    /// Inodes recorded in the durable open-unlink orphan set. After a clean
+    /// restart this is always empty (the startup drain reclaims them), but the
+    /// online state, an inode with nlink==0, no directory entry, present in
+    /// this set is legal and must not be flagged as an orphaned inode.
+    orphan_inodes: HashSet<InodeId>,
 }
 
 impl<'a> ConsistencyChecker<'a> {
@@ -360,17 +376,20 @@ impl<'a> ConsistencyChecker<'a> {
             subdir_counts: HashMap::new(),
             tombstone_inodes: HashSet::new(),
             directory_inodes: HashSet::new(),
+            orphan_inodes: HashSet::new(),
         }
     }
 
     pub async fn verify_all(mut self) -> Result<ConsistencyReport, FsError> {
         self.enumerate_inodes().await?;
         self.enumerate_tombstones().await?;
+        self.enumerate_orphans().await?;
         self.walk_directory_tree(0).await?;
         self.verify_directory_counts().await?;
         self.verify_nlink_counts().await?;
         self.verify_directory_nlinks().await?;
         self.find_orphaned_inodes()?;
+        self.verify_orphan_set_drained();
         self.verify_stats_counters().await?;
         self.verify_tombstones().await?;
         self.verify_file_chunks().await?;
@@ -424,6 +443,22 @@ impl<'a> ConsistencyChecker<'a> {
         while let Some(result) = tombstones.next().await {
             if let Ok(entry) = result {
                 self.tombstone_inodes.insert(entry.inode_id);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn enumerate_orphans(&mut self) -> Result<(), FsError> {
+        let orphans = match self.fs.orphan_store.list().await {
+            Ok(o) => o,
+            Err(_) => return Ok(()),
+        };
+        futures::pin_mut!(orphans);
+
+        while let Some(result) = orphans.next().await {
+            if let Ok(inode_id) = result {
+                self.orphan_inodes.insert(inode_id);
             }
         }
 
@@ -525,6 +560,11 @@ impl<'a> ConsistencyChecker<'a> {
             if inode_id == ROOT_INODE_ID {
                 continue;
             }
+            // An open-unlink orphan (nlink==0, present in the orphan set, no
+            // directory entry) is legal while online
+            if self.orphan_inodes.contains(&inode_id) {
+                continue;
+            }
             if !self.inode_refs.contains_key(&inode_id) {
                 self.report
                     .errors
@@ -533,6 +573,17 @@ impl<'a> ConsistencyChecker<'a> {
             }
         }
         Ok(())
+    }
+
+    fn verify_orphan_set_drained(&mut self) {
+        // The checker runs after a clean restart, by which point the startup
+        // drain must have reclaimed every orphan. A surviving entry means the
+        // drain failed to make progress.
+        for &inode_id in &self.orphan_inodes {
+            self.report
+                .errors
+                .push(ConsistencyError::LeakedOrphan { inode_id });
+        }
     }
 
     async fn verify_stats_counters(&mut self) -> Result<(), FsError> {

--- a/zerofs/tests/failpoints/mod.rs
+++ b/zerofs/tests/failpoints/mod.rs
@@ -2753,3 +2753,239 @@ async fn test_crash_hardlink_unlink_after_commit() {
         _ => unreachable!(),
     }
 }
+
+async fn orphan_set_empty(fs: &ZeroFS) -> bool {
+    use futures::StreamExt;
+    let stream = fs.orphan_store.list().await.unwrap();
+    futures::pin_mut!(stream);
+    stream.next().await.is_none()
+}
+
+/// The consistency checker, run against a LIVE (non-drained) filesystem, must
+/// exempt a legitimate open-unlinked orphan (nlink==0, in the orphan set) yet
+/// still flag a genuine leak (nlink==0, unreachable, NOT in the set). Every
+/// other consistency assertion runs post-restart, after the orphan set is
+/// already drained, so without this the exemption branch is never exercised.
+#[tokio::test]
+async fn test_consistency_live_orphan_exempt_but_leak_flagged() {
+    let (
+        _scenario,
+        TestSetup {
+            fs, creds, auth, ..
+        },
+    ) = TestSetup::new().await;
+
+    // Legitimate live orphan: open-unlinked, kept in the orphan set.
+    let (good_id, _) = fs
+        .create(&creds, 0, b"good", &SetAttributes::default())
+        .await
+        .unwrap();
+    fs.open_handle_inc(good_id);
+    fs.remove(&auth, 0, b"good").await.unwrap();
+
+    // The find_orphaned_inodes exemption must skip the live orphan: no
+    // OrphanedInode error for it. (verify_consistency as a whole is a
+    // post-restart check -- it additionally reports LeakedOrphan + a stats
+    // mismatch for a still-deferred orphan; those are expected online and are
+    // not what this test guards.)
+    let report = verify_consistency(&fs).await.unwrap();
+    assert!(
+        !report.errors.iter().any(|e| matches!(
+            e,
+            consistency::ConsistencyError::OrphanedInode { inode_id } if *inode_id == good_id
+        )),
+        "live open-unlinked orphan wrongly flagged as OrphanedInode: {:?}",
+        report.errors
+    );
+
+    // Genuine leak: defer an inode, then drop its orphan key WITHOUT reclaiming,
+    // leaving nlink==0 + unreachable + not in the orphan set.
+    let (leak_id, _) = fs
+        .create(&creds, 0, b"leak", &SetAttributes::default())
+        .await
+        .unwrap();
+    fs.open_handle_inc(leak_id);
+    fs.remove(&auth, 0, b"leak").await.unwrap();
+    {
+        let mut txn = fs.db.new_transaction().unwrap();
+        fs.orphan_store.remove(&mut txn, leak_id);
+        fs.write_coordinator.commit(txn).await.unwrap();
+    }
+
+    let report = verify_consistency(&fs).await.unwrap();
+    assert!(
+        report.errors.iter().any(|e| matches!(
+            e,
+            consistency::ConsistencyError::OrphanedInode { inode_id } if *inode_id == leak_id
+        )),
+        "genuine orphan leak must be flagged; errors: {:?}",
+        report.errors
+    );
+}
+
+/// A panic at REMOVE_AFTER_ORPHAN_ADD is pre-commit: the orphan-add, nlink=0,
+/// and dir-entry removal all live in the not-yet-committed txn, so a crash
+/// there loses the whole unlink. After restart the file is fully present and
+/// reachable, and the orphan set is empty.
+#[tokio::test]
+async fn test_crash_open_unlink_after_orphan_add() {
+    let (
+        _scenario,
+        TestSetup {
+            ctx,
+            fs,
+            creds,
+            auth,
+        },
+    ) = TestSetup::new().await;
+
+    let (file_id, _) = fs
+        .create(&creds, 0, b"victim.txt", &SetAttributes::default())
+        .await
+        .unwrap();
+    fs.write(&auth, file_id, 0, &Bytes::from(vec![7u8; 5000]))
+        .await
+        .unwrap();
+    fs.flush_coordinator.flush().await.unwrap();
+
+    // Pin the inode open so remove() takes the defer branch.
+    fs.open_handle_inc(file_id);
+
+    fail::cfg(fp::REMOVE_AFTER_ORPHAN_ADD, "panic").unwrap();
+    let fs_clone = Arc::clone(&fs);
+    let auth_clone = auth.clone();
+    let handle =
+        tokio::task::spawn(async move { fs_clone.remove(&auth_clone, 0, b"victim.txt").await });
+    let _ = handle.await;
+    fail::cfg(fp::REMOVE_AFTER_ORPHAN_ADD, "off").unwrap();
+    drop(fs);
+
+    let fs_after = ctx.restart_fs().await;
+    let report = verify_consistency(&fs_after).await.unwrap();
+    assert!(
+        report.is_consistent(),
+        "Inconsistent after crash at remove_after_orphan_add: {:?}",
+        report.errors
+    );
+    assert!(
+        orphan_set_empty(&fs_after).await,
+        "orphan set must be empty"
+    );
+
+    // Unlink never committed: the file is still present and reachable.
+    let creds = test_creds();
+    let id = fs_after
+        .lookup(&creds, 0, b"victim.txt")
+        .await
+        .expect("file should still exist");
+    match fs_after.inode_store.get(id).await.unwrap() {
+        Inode::File(f) => assert_eq!(f.size, 5000),
+        _ => unreachable!(),
+    }
+}
+
+/// Defer commits cleanly, then the process crashes before the open fid is
+/// clunked. The startup drain reclaims the orphan: inode + chunks gone, orphan
+/// set empty, namespace effect (name absent) preserved.
+#[tokio::test]
+async fn test_crash_open_unlink_committed_then_crash_drains() {
+    let (
+        _scenario,
+        TestSetup {
+            ctx,
+            fs,
+            creds,
+            auth,
+        },
+    ) = TestSetup::new().await;
+
+    let (file_id, _) = fs
+        .create(&creds, 0, b"victim.txt", &SetAttributes::default())
+        .await
+        .unwrap();
+    fs.write(&auth, file_id, 0, &Bytes::from(vec![9u8; 5000]))
+        .await
+        .unwrap();
+    fs.flush_coordinator.flush().await.unwrap();
+
+    fs.open_handle_inc(file_id);
+    // Defer commits (no failpoint armed).
+    fs.remove(&auth, 0, b"victim.txt").await.unwrap();
+    fs.flush_coordinator.flush().await.unwrap();
+    drop(fs); // crash before the clunk that would have reclaimed it
+
+    let fs_after = ctx.restart_fs().await; // drain runs in new_with_slatedb
+    let report = verify_consistency(&fs_after).await.unwrap();
+    assert!(
+        report.is_consistent(),
+        "Inconsistent after open-unlink+crash drain: {:?}",
+        report.errors
+    );
+    assert!(
+        orphan_set_empty(&fs_after).await,
+        "startup drain must empty the orphan set"
+    );
+    // Namespace effect preserved and inode reclaimed.
+    assert!(matches!(
+        fs_after.lookup(&test_creds(), 0, b"victim.txt").await,
+        Err(zerofs::fs::errors::FsError::NotFound)
+    ));
+    assert!(matches!(
+        fs_after.inode_store.get(file_id).await,
+        Err(zerofs::fs::errors::FsError::NotFound)
+    ));
+}
+
+/// A panic at CLUNK_AFTER_RECLAIM_INODE_DELETE is pre-commit: the reclaim txn
+/// (inode delete + chunk delete + stats delta + orphan-remove) never lands, so
+/// the orphan key survives. The next startup drain re-runs reclaim exactly
+/// once (idempotent), leaving a consistent, drained filesystem.
+#[tokio::test]
+async fn test_crash_reclaim_after_inode_delete_redrains() {
+    let (
+        _scenario,
+        TestSetup {
+            ctx,
+            fs,
+            creds,
+            auth,
+        },
+    ) = TestSetup::new().await;
+
+    let (file_id, _) = fs
+        .create(&creds, 0, b"victim.txt", &SetAttributes::default())
+        .await
+        .unwrap();
+    fs.write(&auth, file_id, 0, &Bytes::from(vec![3u8; 5000]))
+        .await
+        .unwrap();
+    fs.flush_coordinator.flush().await.unwrap();
+
+    fs.open_handle_inc(file_id);
+    fs.remove(&auth, 0, b"victim.txt").await.unwrap();
+    fs.flush_coordinator.flush().await.unwrap();
+
+    // Last clunk triggers reclaim; panic mid-reclaim before commit.
+    fail::cfg(fp::CLUNK_AFTER_RECLAIM_INODE_DELETE, "panic").unwrap();
+    let fs_clone = Arc::clone(&fs);
+    let handle = tokio::task::spawn(async move { fs_clone.handle_closed(file_id).await });
+    let _ = handle.await;
+    fail::cfg(fp::CLUNK_AFTER_RECLAIM_INODE_DELETE, "off").unwrap();
+    drop(fs);
+
+    let fs_after = ctx.restart_fs().await; // drain re-runs reclaim
+    let report = verify_consistency(&fs_after).await.unwrap();
+    assert!(
+        report.is_consistent(),
+        "Inconsistent after crash mid-reclaim: {:?}",
+        report.errors
+    );
+    assert!(
+        orphan_set_empty(&fs_after).await,
+        "drain must reclaim the orphan after the lost reclaim txn"
+    );
+    assert!(matches!(
+        fs_after.inode_store.get(file_id).await,
+        Err(zerofs::fs::errors::FsError::NotFound)
+    ));
+}


### PR DESCRIPTION
Unlinking a file that an open 9P fid still references used to delete the inode immediately, so reads/writes on the open fid returned EIO. Keep the inode alive while nlink>0 OR an open handle references it, and reclaim it only when both reach zero.