### PR TITLE
[codex] Preserve Jepsen timeout values

### DIFF
--- a/jepsen/ha/src/zerofs_ha/core.clj
+++ b/jepsen/ha/src/zerofs_ha/core.clj
@@ -419,12 +419,12 @@
                   :corrupt (corrupt-files dir))
            (catch java.io.IOException e
              (assoc op :type :fail :error (.getMessage e))))
-      (util/timeout 30000 (assoc op :type :info :error :timeout)
-        (case (:f op)
-          ;; Assign a unique value, record it under this worker, then create it.
-          :add (let [v (swap! counter inc)
-                     f (io/file (subdir dir v) (str v))]
-                 (swap! live update (:process op) (fnil conj #{}) v)
+      (case (:f op)
+        ;; Assign a unique value, record it under this worker, then create it.
+        :add (let [v (swap! counter inc)
+                   f (io/file (subdir dir v) (str v))]
+               (swap! live update (:process op) (fnil conj #{}) v)
+               (util/timeout 30000 (assoc op :type :info :value v :error :timeout)
                  (try
                    (add-file! dir v)
                    (when fsync? (fsync-sentinel! dir))
@@ -445,11 +445,12 @@
                          (assoc op :type :info :value v :error :retried-create)
                          (re-find #"(?i)no such file|not found" msg)
                          (assoc op :type :info :value v :error :not-durable-here)
-                         :else (assoc op :type :fail :value v :error msg))))))
-          ;; Remove one of THIS worker's live values (none queued -> nothing to do).
-          :remove (if-let [v (first (get @live (:process op)))]
-                    (let [f (io/file (subdir dir v) (str v))]
-                      (swap! live update (:process op) disj v)
+                         :else (assoc op :type :fail :value v :error msg)))))))
+        ;; Remove one of THIS worker's live values (none queued -> nothing to do).
+        :remove (if-let [v (first (get @live (:process op)))]
+                  (let [f (io/file (subdir dir v) (str v))]
+                    (swap! live update (:process op) disj v)
+                    (util/timeout 30000 (assoc op :type :info :value v :error :timeout)
                       (try
                         (remove-file! dir v)
                         (when fsync? (fsync-sentinel! dir))
@@ -463,28 +464,31 @@
                             (assoc op :type :info :value v :error :still-present-here)
                             (assoc op :type :ok :value v)))
                         (catch java.io.IOException e
-                          (assoc op :type :info :value v :error (.getMessage e)))))
-                    (assoc op :type :fail :error :nothing-to-remove))
-          ;; An acknowledged write WITHOUT fsync: it lives in the leader memtable +
-          ;; the standby tail, not yet on the object store. :ok means acked (and
-          ;; readable here now), NOT durable.
-          :write (let [v (swap! counter inc)
-                       f (io/file (subdir dir v) (str v))]
+                          (assoc op :type :info :value v :error (.getMessage e))))))
+                  (assoc op :type :fail :error :nothing-to-remove))
+        ;; An acknowledged write WITHOUT fsync: it lives in the leader memtable +
+        ;; the standby tail, not yet on the object store. :ok means acked (and
+        ;; readable here now), NOT durable.
+        :write (let [v (swap! counter inc)
+                     f (io/file (subdir dir v) (str v))]
+                 (util/timeout 30000 (assoc op :type :info :value v :error :timeout)
                    (try
                      (add-file! dir v)
                      (if (= (str v "\n") (slurp f))
                        (assoc op :type :ok :value v)
                        (assoc op :type :info :value v :error :content-not-here))
                      (catch java.io.IOException e
-                       (assoc op :type :info :value v :error (str (.getMessage e))))))
-          ;; A global fsync durability barrier. :ok = the barrier held; an error
-          ;; (after the fix, a fsync that spans a recovery which dropped this
-          ;; client's un-fsync'd writes) surfaces here as :fail.
-          :fsync (try (fsync-sentinel! dir) (assoc op :type :ok)
+                       (assoc op :type :info :value v :error (str (.getMessage e)))))))
+        ;; A global fsync durability barrier. :ok = the barrier held; an error
+        ;; (after the fix, a fsync that spans a recovery which dropped this
+        ;; client's un-fsync'd writes) surfaces here as :fail.
+        :fsync (util/timeout 30000 (assoc op :type :info :error :timeout)
+                 (try (fsync-sentinel! dir) (assoc op :type :ok)
                       (catch java.io.IOException e
-                        (assoc op :type :fail :error (str (.getMessage e)))))
-          ;; Drop leftover temps (interrupted renames) before the final read/statfs.
-          :cleanup (try (cleanup-temps! dir) (assoc op :type :ok)
+                        (assoc op :type :fail :error (str (.getMessage e))))))
+        ;; Drop leftover temps (interrupted renames) before the final read/statfs.
+        :cleanup (util/timeout 30000 (assoc op :type :info :error :timeout)
+                   (try (cleanup-temps! dir) (assoc op :type :ok)
                         (catch java.io.IOException e
                           (assoc op :type :fail :error (.getMessage e))))))))
   (teardown! [_ _test])


### PR DESCRIPTION
## Summary

This fixes the HA Jepsen set client so timed-out operations retain the value they were acting on.

- Move the `util/timeout` fallback inside the `:add`, `:remove`, and `:write` branches after each operation binds its value.
- Preserve `:value` on timeout results for `:add`, `:remove`, and `:write`.
- Keep `:fsync` and `:cleanup` timeout results value-less because those operations do not act on a set element.

## Root Cause

The set checker already handles `[:info :remove]` with a concrete value correctly: it marks that value as indeterminate, because a timed-out remove may still complete after the client gives up waiting.

However, `SetClient.invoke!` previously wrapped the entire non-read operation dispatch in one outer timeout fallback:

```clojure
(util/timeout 30000 (assoc op :type :info :error :timeout)
  ...)
```

That fallback was created before `:add`, `:remove`, and `:write` selected or allocated a value. When a `:remove` timed out, Jepsen recorded an operation like:

```clojure
{:type :info, :f :remove, :value nil, :error :timeout}
```

The checker groups only operations with a non-nil `:value`, so that timed-out remove was ignored. If the filesystem operation later completed and deleted the file, the checker still considered the earlier `:ok :add` definitely required. The final read then made a correctly deleted value look like a lost acknowledged add.

## Investigation Evidence

An instrumented failing 600 second run reported:

```clojure
:lost [182 454 1006 1011 1019]
```

For all five reported lost values, the ZeroFS node logs showed later committed final-name deletes:

- `182`: delete shipped at epoch 4 seqno 1 and received by the standby.
- `454`: delete shipped at epoch 4 seqno 26 and received by the standby.
- `1006`: delete shipped at epoch 6 seqno 151 and received by the standby.
- `1011`: delete shipped at epoch 6 seqno 154 and received by the standby.
- `1019`: delete shipped at epoch 6 seqno 150 and received by the standby.

The same failing run also showed timeout operations without values:

```text
remove_timeout_nil: 6
remove_timeout_with_value: 0
add_timeout_nil: 114
add_timeout_with_value: 0
```

After this patch, a comparable run emitted value-carrying timeout operations instead:

```text
remove_timeout_nil: 0
remove_timeout_with_value: 5
add_timeout_nil: 0
add_timeout_with_value: 79
```

The patched run completed with:

```clojure
:valid? true
:lost-count 0
:corrupt-count 0
```

I also checked the SlateDB LSM instrumentation from the failing run. It did not support the earlier L0/SR compaction-drop hypothesis for this trace:

```text
dropped_l0_not_seen_as_compaction_source: 0
missing_nonempty total: 0
noncontiguous markers: 0
```

## Validation

- `lein test` in the Jepsen VM: 3 tests, 7 assertions, 0 failures, 0 errors.
- `git diff --check HEAD^..HEAD`: clean.
- 600 second HA Jepsen rerun with this patch: valid, lost-count 0, corrupt-count 0.

The long Jepsen rerun was performed in a local Multipass VM. That VM still hit the known `jspawnhelper`/FUSE stall behavior during process recovery, so the run required manual VM recovery steps. The important evidence for this PR is the before/after Jepsen history shape and the old failing run's matching ZeroFS delete commits.