### PR TITLE
Define 9P mutation retry and retention windows

### DIFF
--- a/zerofs/ninep-proto/src/lib.rs
+++ b/zerofs/ninep-proto/src/lib.rs
@@ -7,6 +7,7 @@
 mod deku_bytes;
 mod lock_range;
 mod protocol;
+pub mod retry;
 
 pub use deku_bytes::*;
 pub use lock_range::*;

--- a/zerofs/ninep-proto/src/retry.rs
+++ b/zerofs/ninep-proto/src/retry.rs
@@ -1,0 +1,15 @@
+//! Mutation retry timings shared by 9P clients and servers.
+
+use std::time::Duration;
+
+/// Maximum elapsed time from the first dispatched mutation to a resend using
+/// the same operation ID.
+pub const MUTATION_RETRY_HORIZON: Duration = Duration::from_secs(120);
+
+/// Retention period for a completed mutation result.
+pub const MUTATION_RESULT_RETENTION: Duration = Duration::from_secs(150);
+
+const _: () = assert!(
+    MUTATION_RETRY_HORIZON.as_nanos() < MUTATION_RESULT_RETENTION.as_nanos(),
+    "mutation result retention must exceed the retry horizon"
+);


### PR DESCRIPTION
Add the mutation retry horizon shared by 9P clients and servers, together with the longer completed-result retention period.

A compile-time assertion requires result retention to exceed the resend horizon.

Client retry and server dedup adoption will follow in separate changes.
