### PR TITLE
Define 9P mutation retry signals

### DIFF
--- a/zerofs/ninep-proto/src/protocol.rs
+++ b/zerofs/ninep-proto/src/protocol.rs
@@ -90,12 +90,20 @@ pub enum LockType {
 
 pub const P9_LOCK_FLAGS_BLOCK: u32 = 1; // blocking request
 
-/// `Rlerror` ecode an HA node returns when it is no longer the serving leader
-/// (lease lapsed or fenced). A distinct signal, not generic `EIO`, so a
-/// failover-aware client re-probes and resends rather than failing. The value is
-/// `ESHUTDOWN`, which no filesystem op otherwise produces and degrades sensibly
-/// for clients that don't special-case it.
+/// `Rlerror` code for leadership loss after possible dispatch. Linux `ESHUTDOWN`.
 pub const P9_ENOTLEADER: u32 = 108;
+
+/// `Rlerror` code for leadership rejection before any logical effect. Linux `ENOTCONN`.
+pub const P9_ENOTLEADER_CLEAN: u32 = 107;
+
+/// `Rlerror` code for a retry op-id absent from the deduplication ledgers.
+/// Linux `ESTALE`.
+pub const P9_EOPIDSTALE: u32 = 116;
+
+/// Marks a resend after a potentially dispatched attempt.
+pub const P9_OP_FLAG_RETRY: u8 = 1 << 0;
+/// All defined private request-flag bits.
+pub const P9_OP_KNOWN_FLAGS: u8 = P9_OP_FLAG_RETRY;
 
 /// Maximum 9P message size. This bounds the negotiated msize: the server clamps
 /// every client's requested msize to this value, and both the server and client

--- a/zerofs/src/fs/errors.rs
+++ b/zerofs/src/fs/errors.rs
@@ -37,6 +37,8 @@ pub enum FsError {
     ReadOnlyFilesystem,
     #[error("Leader lease expired (not the current leader)")]
     LeaderLeaseExpired,
+    #[error("Leader rejected before applying the operation")]
+    LeaderRejectedBeforeApply,
     #[error("Server shutting down")]
     ShuttingDown,
 }
@@ -67,6 +69,7 @@ impl From<FsError> for nfsstat3 {
             FsError::InvalidData => nfsstat3::NFS3ERR_IO,
             FsError::ReadOnlyFilesystem => nfsstat3::NFS3ERR_ROFS,
             FsError::LeaderLeaseExpired => nfsstat3::NFS3ERR_IO,
+            FsError::LeaderRejectedBeforeApply => nfsstat3::NFS3ERR_IO,
             FsError::ShuttingDown => nfsstat3::NFS3ERR_IO,
         }
     }
@@ -113,9 +116,8 @@ impl FsError {
             FsError::StaleHandle => libc::ESTALE as u32,
             FsError::InvalidData => libc::EIO as u32,
             FsError::ReadOnlyFilesystem => libc::EROFS as u32,
-            // A distinct signal (not EIO) so a failover-aware 9P client re-probes
-            // the node set for the current leader and resends, instead of failing.
             FsError::LeaderLeaseExpired => ninep_proto::P9_ENOTLEADER,
+            FsError::LeaderRejectedBeforeApply => libc::EIO as u32,
             FsError::ShuttingDown => ninep_proto::P9_ENOTLEADER,
         }
     }


### PR DESCRIPTION
Define private 9P codes for leadership rejection before logical effect and retries missing from the deduplication ledgers, together with the retry request flag.

Represent authoritative pre-apply leader rejection in `FsError` while preserving ordinary `EIO` behavior for non-9P consumers.
