### PR TITLE
Revoke deposed HA writers before returning failures

### DIFF
--- a/zerofs/src/db.rs
+++ b/zerofs/src/db.rs
@@ -386,6 +386,13 @@ impl Db {
         !self.is_deposed()
     }
 
+    /// Permanently revokes the attached HA serving lease.
+    pub fn revoke_lease(&self) {
+        if let Some(lease) = &self.lease {
+            lease.revoke();
+        }
+    }
+
     /// True once no longer the serving leader: the lease is invalid, or the data
     /// db has been closed (fenced by a takeover).
     #[inline]
@@ -925,8 +932,10 @@ mod lease_gate_tests {
         lease.renew(Duration::from_millis(500));
         assert!(db.get_bytes(&key).await.unwrap().is_none());
 
-        // Revoked: refused again.
-        lease.invalidate();
+        db.revoke_lease();
+        lease.renew(Duration::from_millis(500));
+        assert!(!lease.is_valid(), "revocation must be terminal");
+
         assert!(
             db.get_bytes(&key).await.is_err(),
             "read must be refused after the lease is revoked"

--- a/zerofs/src/fs/write_coordinator.rs
+++ b/zerofs/src/fs/write_coordinator.rs
@@ -349,20 +349,20 @@ async fn worker_loop(
             (true, Some(repl)) => Some(repl.ship(&repl_ops, &batch_op_ids).await),
             _ => None,
         };
-        // Rejection is deposal evidence. Fail the batch and force a manifest
-        // update so fencing closes the database without waiting for its poller.
+        // Peer rejection proves this batch was not appended or applied locally.
+        // Revoke serving authority before returning the clean failure.
         let (shipped_seqno, ran_solo) = match ship_outcome {
             Some(ShipOutcome::Deposed) => {
                 tracing::error!(
                     "HA: standby rejected a ship: this leader is deposed; failing the \
                      batch and stepping down"
                 );
-                let _ = ctx.flush_coordinator.flush().await;
+                ctx.db.revoke_lease();
                 if counter_staged {
                     ctx.inode_store.allocate();
                 }
                 for reply in replies {
-                    let _ = reply.send(Err(FsError::IoError));
+                    let _ = reply.send(Err(FsError::LeaderRejectedBeforeApply));
                 }
                 continue;
             }
@@ -846,12 +846,19 @@ mod tests {
 
         let codec = codec();
         let key = codec.extent_key(1, 0);
+        let flushes_before = fs.flush_coordinator.completed_flush_count();
         let mut txn = Transaction::new();
         txn.put_bytes(&key, Bytes::from_static(b"v"));
-        coord
+        let error = coord
             .commit(txn)
             .await
             .expect_err("a deposed leader must fail the batch, not ack it");
+        assert_eq!(error, FsError::LeaderRejectedBeforeApply);
+        assert_eq!(
+            fs.flush_coordinator.completed_flush_count(),
+            flushes_before,
+            "a stale writer must not flush after peer rejection"
+        );
         assert!(
             fs.db.get_bytes(&key).await.unwrap().is_none(),
             "a deposed leader must not apply the rejected batch"
@@ -860,7 +867,10 @@ mod tests {
         // Deposal is terminal: later batches fail too.
         let mut txn = Transaction::new();
         txn.put_bytes(&codec.extent_key(1, 1), Bytes::from_static(b"w"));
-        coord.commit(txn).await.expect_err("deposal must be sticky");
+        assert_eq!(
+            coord.commit(txn).await.expect_err("deposal must be sticky"),
+            FsError::LeaderRejectedBeforeApply
+        );
     }
 
     // The first shipped batch after a solo episode carries the stamp (solo=0)

--- a/zerofs/src/replication/lease.rs
+++ b/zerofs/src/replication/lease.rs
@@ -4,7 +4,7 @@
 //! are the hard guarantees.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// Monotonic-clock validity checked on the read and write path. `valid_until_ms`
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 pub struct Lease {
     base: Instant,
     valid_until_ms: AtomicU64,
+    revoked: AtomicBool,
 }
 
 impl Lease {
@@ -19,6 +20,7 @@ impl Lease {
         Arc::new(Self {
             base: Instant::now(),
             valid_until_ms: AtomicU64::new(0),
+            revoked: AtomicBool::new(false),
         })
     }
 
@@ -28,15 +30,23 @@ impl Lease {
 
     /// Valid for `ttl` from now. Never stores 0 (reserved for "invalid").
     pub fn renew(&self, ttl: Duration) {
+        if self.revoked.load(Ordering::Acquire) {
+            return;
+        }
         let until = self.now_ms().saturating_add(ttl.as_millis() as u64).max(1);
         self.valid_until_ms.store(until, Ordering::Release);
     }
 
-    pub fn invalidate(&self) {
+    /// Permanently revokes the lease.
+    pub fn revoke(&self) {
+        self.revoked.store(true, Ordering::Release);
         self.valid_until_ms.store(0, Ordering::Release);
     }
 
     pub fn is_valid(&self) -> bool {
+        if self.revoked.load(Ordering::Acquire) {
+            return false;
+        }
         let until = self.valid_until_ms.load(Ordering::Acquire);
         until != 0 && self.now_ms() < until
     }
@@ -69,7 +79,7 @@ pub async fn run_lease_from_status(
                      and stepping down"
                 ),
             }
-            lease.invalidate();
+            lease.revoke();
             return;
         }
         lease.renew(lease_ttl);
@@ -79,7 +89,7 @@ pub async fn run_lease_from_status(
             }
             res = status.changed() => {
                 // Channel closed: the data db was dropped, so stop serving.
-                if res.is_err() { lease.invalidate(); return; }
+                if res.is_err() { lease.revoke(); return; }
             }
             _ = tokio::time::sleep(renew_interval) => {}
         }
@@ -104,8 +114,10 @@ mod tests {
         lease.renew(Duration::from_millis(60));
         assert!(lease.is_valid());
 
-        lease.invalidate();
-        assert!(!lease.is_valid(), "invalidate revokes immediately");
+        lease.revoke();
+        assert!(!lease.is_valid(), "revoke takes effect immediately");
+        lease.renew(Duration::from_millis(60));
+        assert!(!lease.is_valid(), "revocation is terminal");
     }
 
     async fn open_db(name: &str) -> slatedb::Db {


### PR DESCRIPTION
Make HA lease revocation terminal so later renewal attempts cannot restore serving authority.

When a standby rejects a batch as deposed, revoke the local lease without flushing or applying the batch and return `LeaderRejectedBeforeApply`.
