### PR TITLE
fix: bound replay stalls without restarting healthy large sessions

### DIFF
--- a/kernel/client/mod.rs
+++ b/kernel/client/mod.rs
@@ -199,8 +199,11 @@ const RECONNECT_BACKOFF_MAX_MS: u64 = 500;
 /// is exactly where memory is least likely to be available.
 const REPLAY_FRAME_BYTES: usize = 256;
 
-/// Maximum time a replacement connection may take to rebuild recorded fids.
-const REPLAY_TIMEOUT_MS: u64 = 30_000;
+/// Longest replay interval allowed without completing a new state record.
+///
+/// A fixed deadline for the complete replay livelocks a mount with enough live
+/// fids: every healthy candidate is discarded after rebuilding the same prefix.
+const REPLAY_STALL_TIMEOUT_MS: u64 = 30_000;
 
 /// Byte-range locks one mount may hold at once.
 ///
@@ -214,8 +217,8 @@ const REPLAY_TIMEOUT_MS: u64 = 30_000;
 /// unlock is taken before its caller gives up the local grant.
 ///
 /// The value is a replay cost as much as a memory one. Every record is one
-/// round trip on every reconnect, so a set this size already costs more of the
-/// replay timeout than a mount should spend.
+/// round trip on every reconnect, so even a progressing replay of a full set
+/// can add substantial recovery latency.
 const MAX_LOCK_RECORDS: usize = 1024;
 
 /// Bytes in the per-mount lock owner identity: `zerofs-` plus a hex UUID.

--- a/kernel/client/reconnect.rs
+++ b/kernel/client/reconnect.rs
@@ -30,7 +30,8 @@ use super::session::{Session, SessionStatus};
 use super::slots::ExpectedResponse;
 use super::{
     CLIENT_ID_LEN, MIN_MSIZE, RECONNECT_BACKOFF_MAX_MS, RECONNECT_BACKOFF_MIN_MS,
-    REPLAY_FRAME_BYTES, REPLAY_TIMEOUT_MS, ROOT_FID, ROOT_INODE_ID, jiffies_for_ms, monotonic_ns,
+    REPLAY_FRAME_BYTES, REPLAY_STALL_TIMEOUT_MS, ROOT_FID, ROOT_INODE_ID, jiffies_for_ms,
+    monotonic_ns,
 };
 
 pub(super) struct BootstrappedTransport {
@@ -164,17 +165,22 @@ impl Session {
     /// granted on the connection this one replaces carries its epoch, so its
     /// store is refused rather than landing behind the pass below.
     fn replay_session(&self, transport: &SocketTransport) -> Result<()> {
-        let deadline_ns =
-            monotonic_ns().saturating_add(REPLAY_TIMEOUT_MS.saturating_mul(1_000_000));
+        let mut stall_deadline_ns = replay_stall_deadline_ns();
         let mut io = [0u8; REPLAY_FRAME_BYTES];
         let mut gone: KVec<(u32, bool)> = KVec::new();
+        let mut completed_fids = 0usize;
 
         // Attach roots must exist before descendants resolve against them.
         for roots in [true, false] {
             let mut from = 0usize;
             while let Some((index, record, credentials)) = self.next_replay_record(from, roots)? {
                 from = index.saturating_add(1);
-                if monotonic_ns() >= deadline_ns {
+                if monotonic_ns() >= stall_deadline_ns {
+                    pr_warn!(
+                        "zerofs: fid replay made no progress for {}ms after {} records\n",
+                        REPLAY_STALL_TIMEOUT_MS,
+                        completed_fids
+                    );
                     return Err(ETIMEDOUT);
                 }
                 let fid = index as u32;
@@ -192,6 +198,8 @@ impl Session {
                     }
                     ReplayOutcome::Gone => gone.push((fid, record.opened), GFP_KERNEL)?,
                 }
+                completed_fids = completed_fids.saturating_add(1);
+                stall_deadline_ns = replay_stall_deadline_ns();
             }
         }
 
@@ -224,7 +232,7 @@ impl Session {
         // to reinstall first; a Tlock on a fid this connection does not have
         // earns EBADF, which is neither a conflict nor a lost object, so it
         // would fail every reconnect round forever.
-        self.replay_locks(transport, &mut io, deadline_ns)
+        self.replay_locks(transport, &mut io, &mut stall_deadline_ns)
     }
 
     /// Reinstall the complete recorded lock set on `transport`.
@@ -239,45 +247,74 @@ impl Session {
         &self,
         transport: &SocketTransport,
         io: &mut [u8],
-        deadline_ns: u64,
+        stall_deadline_ns: &mut u64,
     ) -> Result<()> {
         // Declared out here so it keeps growing across attempts rather than
         // restarting at the minimum on every retry.
         let mut backoff_ms = RECONNECT_BACKOFF_MIN_MS;
+        let mut high_water = 0usize;
         'attempt: loop {
             // What this pass holds, as an exclusive bound on record indices.
             let mut acquired = 0usize;
+            let mut completed = 0usize;
             let mut from = 0usize;
             while let Some((index, record)) = self.next_replay_lock(from) {
                 from = index.saturating_add(1);
-                if monotonic_ns() >= deadline_ns {
+                if monotonic_ns() >= *stall_deadline_ns {
                     // The candidate is discarded on this error and its Tversion
-                    // releases the prefix, which is more than a rollback past
-                    // the deadline could promise.
+                    // releases the prefix, which is more than a rollback after
+                    // a stalled candidate could promise.
+                    pr_warn!(
+                        "zerofs: lock replay made no progress for {}ms after {} records\n",
+                        REPLAY_STALL_TIMEOUT_MS,
+                        high_water
+                    );
                     return Err(ETIMEDOUT);
                 }
                 match self.replay_lock_step(transport, io, &record) {
-                    Ok(LockReplayOutcome::Acquired) => acquired = from,
+                    Ok(LockReplayOutcome::Acquired) => {
+                        acquired = from;
+                        completed = completed.saturating_add(1);
+                        if completed > high_water {
+                            high_water = completed;
+                            *stall_deadline_ns = replay_stall_deadline_ns();
+                        }
+                    }
                     Ok(LockReplayOutcome::Conflict) => {
-                        if !self.rollback_replayed_locks(transport, io, acquired, deadline_ns) {
+                        if !self.rollback_replayed_locks(
+                            transport,
+                            io,
+                            acquired,
+                            *stall_deadline_ns,
+                        ) {
                             // Ranges may still be held under a prefix this
                             // client can no longer account for. EAGAIN is
                             // non-terminal, so the candidate is discarded and
                             // its Tversion is what releases them.
                             return Err(EAGAIN);
                         }
-                        self.replay_conflict_backoff(backoff_ms, deadline_ns)?;
+                        self.replay_conflict_backoff(backoff_ms, *stall_deadline_ns)?;
                         backoff_ms = backoff_ms.saturating_mul(2).min(RECONNECT_BACKOFF_MAX_MS);
                         continue 'attempt;
                     }
                     // Rollback first: replay_state_lost shuts the candidate
                     // down, and these unlocks still have to reach it.
                     Ok(LockReplayOutcome::Refused(reason)) => {
-                        self.rollback_replayed_locks(transport, io, acquired, deadline_ns);
+                        self.rollback_replayed_locks(
+                            transport,
+                            io,
+                            acquired,
+                            *stall_deadline_ns,
+                        );
                         return Err(self.replay_state_lost(reason));
                     }
                     Err(error) => {
-                        self.rollback_replayed_locks(transport, io, acquired, deadline_ns);
+                        self.rollback_replayed_locks(
+                            transport,
+                            io,
+                            acquired,
+                            *stall_deadline_ns,
+                        );
                         return Err(error);
                     }
                 }
@@ -570,6 +607,10 @@ impl Session {
         self.terminate(error);
         error
     }
+}
+
+fn replay_stall_deadline_ns() -> u64 {
+    monotonic_ns().saturating_add(REPLAY_STALL_TIMEOUT_MS.saturating_mul(1_000_000))
 }
 
 /// Whether a replayed fid, or one step of its replay, was restored or is gone.

--- a/kernel/client/reconnect.rs
+++ b/kernel/client/reconnect.rs
@@ -198,6 +198,14 @@ impl Session {
                     }
                     ReplayOutcome::Gone => gone.push((fid, record.opened), GFP_KERNEL)?,
                 }
+                if monotonic_ns() >= stall_deadline_ns {
+                    pr_warn!(
+                        "zerofs: fid replay progress arrived after the {}ms stall deadline at {} records\n",
+                        REPLAY_STALL_TIMEOUT_MS,
+                        completed_fids
+                    );
+                    return Err(ETIMEDOUT);
+                }
                 completed_fids = completed_fids.saturating_add(1);
                 stall_deadline_ns = replay_stall_deadline_ns();
             }
@@ -273,6 +281,14 @@ impl Session {
                 }
                 match self.replay_lock_step(transport, io, &record) {
                     Ok(LockReplayOutcome::Acquired) => {
+                        if monotonic_ns() >= *stall_deadline_ns {
+                            pr_warn!(
+                                "zerofs: lock replay progress arrived after the {}ms stall deadline at {} records\n",
+                                REPLAY_STALL_TIMEOUT_MS,
+                                high_water
+                            );
+                            return Err(ETIMEDOUT);
+                        }
                         acquired = from;
                         completed = completed.saturating_add(1);
                         if completed > high_water {

--- a/zerofs/ninep-client/Cargo.toml
+++ b/zerofs/ninep-client/Cargo.toml
@@ -42,3 +42,6 @@ web-sys = { version = "0.3", features = [
     "Performance",
     "WebSocket",
 ] }
+
+[dev-dependencies]
+tokio = { version = "1.52", features = ["test-util"] }

--- a/zerofs/ninep-client/src/lib.rs
+++ b/zerofs/ninep-client/src/lib.rs
@@ -181,10 +181,11 @@ struct ReplayProgressState {
 struct ReplayProgress {
     state: Mutex<ReplayProgressState>,
     advanced: Notify,
+    stall_timeout: Duration,
 }
 
-impl Default for ReplayProgress {
-    fn default() -> Self {
+impl ReplayProgress {
+    fn new(stall_timeout: Duration) -> Self {
         Self {
             state: Mutex::new(ReplayProgressState {
                 completed: 0,
@@ -192,25 +193,32 @@ impl Default for ReplayProgress {
                 last_advance: runtime::Clock::now(),
             }),
             advanced: Notify::new(),
+            stall_timeout,
         }
     }
-}
 
-impl ReplayProgress {
     fn set_total(&self, total: usize) {
         self.state.lock().unwrap().total = total as u64;
     }
 
-    fn reach(&self, completed: usize) {
+    /// Records a new high-water mark unless the previous one has already
+    /// stalled. Returning `false` prevents a late replay response from
+    /// reviving an expired candidate before the watchdog task is polled.
+    fn reach(&self, completed: usize) -> bool {
         let mut state = self.state.lock().unwrap();
+        let now = runtime::Clock::now();
+        if now.duration_since(&state.last_advance) >= self.stall_timeout {
+            return false;
+        }
         let completed = completed as u64;
         if completed <= state.completed {
-            return;
+            return true;
         }
         state.completed = completed;
-        state.last_advance = runtime::Clock::now();
+        state.last_advance = now;
         drop(state);
         self.advanced.notify_waiters();
+        true
     }
 
     fn snapshot(&self) -> (u64, u64) {
@@ -218,9 +226,10 @@ impl ReplayProgress {
         (state.completed, state.total)
     }
 
-    fn stall_remaining(&self, stall_timeout: Duration) -> Option<Duration> {
-        let elapsed = self.state.lock().unwrap().last_advance.elapsed();
-        stall_timeout
+    fn stall_remaining(&self) -> Option<Duration> {
+        let state = self.state.lock().unwrap();
+        let elapsed = runtime::Clock::now().duration_since(&state.last_advance);
+        self.stall_timeout
             .checked_sub(elapsed)
             .filter(|remaining| !remaining.is_zero())
     }
@@ -230,11 +239,7 @@ impl ReplayProgress {
 ///
 /// Keeping the original future across watchdog windows is important: restarting
 /// it would reproduce the reconnect livelock this helper is meant to prevent.
-async fn timeout_on_stall<F>(
-    stall_timeout: Duration,
-    progress: &ReplayProgress,
-    future: F,
-) -> Result<F::Output, ()>
+async fn timeout_on_stall<F>(progress: &ReplayProgress, future: F) -> Result<F::Output, ()>
 where
     F: std::future::Future,
 {
@@ -245,16 +250,21 @@ where
         // time elapsed since the event rather than since this task was polled.
         let mut advanced = Box::pin(progress.advanced.notified());
         advanced.as_mut().enable();
-        let Some(remaining) = progress.stall_remaining(stall_timeout) else {
+        let Some(remaining) = progress.stall_remaining() else {
             return Err(());
         };
         let wake = Box::pin(async {
             let timer = Box::pin(runtime::sleep(remaining));
             let _ = select(advanced, timer).await;
         });
-        match select(future, wake).await {
-            Either::Left((output, _)) => return Ok(output),
-            Either::Right(((), pending)) => future = pending,
+        // Poll the wake side first. If both the replay and its timer became
+        // ready while this task was delayed, expiry must win. Recheck before
+        // accepting output to also cover a deadline crossed during one poll.
+        match select(wake, future).await {
+            Either::Left(((), pending)) => future = pending,
+            Either::Right((output, _)) => {
+                return progress.stall_remaining().map(|_| output).ok_or(());
+            }
         }
     }
 }
@@ -1002,9 +1012,8 @@ impl NinePClient {
         // Settlement and snapshot/replay/install are mutually exclusive.
         let _transition = self.session_transition.lock().await;
         debug_assert_eq!(msize, self.msize);
-        let progress = ReplayProgress::default();
+        let progress = ReplayProgress::new(REPLAY_STALL_TIMEOUT);
         match timeout_on_stall(
-            REPLAY_STALL_TIMEOUT,
             &progress,
             self.replay_with_progress(&conn, &progress, || Self::has_external_owner(self)),
         )
@@ -1050,7 +1059,7 @@ impl NinePClient {
     /// Rebuilds recorded fids and locks on `conn`. Roots precede descendants.
     #[cfg(test)]
     async fn replay(&self, conn: &Conn) -> ClientResult<()> {
-        let progress = ReplayProgress::default();
+        let progress = ReplayProgress::new(REPLAY_STALL_TIMEOUT);
         self.replay_with_progress(conn, &progress, || true).await
     }
 
@@ -1092,7 +1101,9 @@ impl NinePClient {
                     gone_unopened.push(fid);
                 }
                 completed_fids = completed_fids.saturating_add(1);
-                progress.reach(completed_fids);
+                if !progress.reach(completed_fids) {
+                    return Err(ClientError::Disconnected);
+                }
                 continue;
             }
             if let Some(flags) = rec.opened {
@@ -1119,7 +1130,9 @@ impl NinePClient {
             }
             ensure_replay_owned(&keep_replaying)?;
             completed_fids = completed_fids.saturating_add(1);
-            progress.reach(completed_fids);
+            if !progress.reach(completed_fids) {
+                return Err(ClientError::Disconnected);
+            }
         }
 
         let mut conflict_backoff = RECONNECT_BACKOFF_MIN;
@@ -1147,7 +1160,9 @@ impl NinePClient {
                         let completed_locks = lock_index.saturating_add(1);
                         if completed_locks > lock_high_water {
                             lock_high_water = completed_locks;
-                            progress.reach(fid_count.saturating_add(lock_high_water));
+                            if !progress.reach(fid_count.saturating_add(lock_high_water)) {
+                                return Err(ClientError::Disconnected);
+                            }
                         }
                     }
                     Ok(Message::Rlock(Rlock {
@@ -3376,53 +3391,74 @@ mod session_transition_tests {
 
     #[tokio::test(start_paused = true)]
     async fn replay_watchdog_allows_total_work_longer_than_one_stall_window() {
-        let progress = ReplayProgress::default();
+        let progress = ReplayProgress::new(Duration::from_secs(30));
         let work = async {
             for completed in 1..=6 {
                 runtime::sleep(Duration::from_secs(17)).await;
-                progress.reach(completed);
+                assert!(progress.reach(completed));
             }
             42
         };
 
-        assert_eq!(
-            timeout_on_stall(Duration::from_secs(30), &progress, work).await,
-            Ok(42)
-        );
+        assert_eq!(timeout_on_stall(&progress, work).await, Ok(42));
     }
 
     #[tokio::test(start_paused = true)]
     async fn replay_watchdog_rejects_a_candidate_that_stops_progressing() {
-        let progress = ReplayProgress::default();
-        progress.reach(7);
+        let progress = ReplayProgress::new(Duration::from_secs(30));
+        assert!(progress.reach(7));
 
         assert!(
-            timeout_on_stall(
-                Duration::from_secs(30),
-                &progress,
-                std::future::pending::<()>(),
-            )
-            .await
-            .is_err()
+            timeout_on_stall(&progress, std::future::pending::<()>())
+                .await
+                .is_err()
         );
     }
 
     #[tokio::test(start_paused = true)]
     async fn replay_watchdog_measures_from_the_last_progress_event() {
-        let progress = ReplayProgress::default();
+        let progress = ReplayProgress::new(Duration::from_secs(30));
         let started = tokio::time::Instant::now();
         let work = async {
             runtime::sleep(Duration::from_secs(1)).await;
-            progress.reach(1);
+            assert!(progress.reach(1));
             std::future::pending::<()>().await;
         };
 
-        assert!(
-            timeout_on_stall(Duration::from_secs(30), &progress, work)
-                .await
-                .is_err()
-        );
+        assert!(timeout_on_stall(&progress, work).await.is_err());
         assert_eq!(started.elapsed(), Duration::from_secs(31));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replay_watchdog_prioritizes_an_expired_timer_over_ready_replay() {
+        let progress = ReplayProgress::new(Duration::from_secs(30));
+        let (release, released) = oneshot::channel::<()>();
+        let work = async {
+            released.await.unwrap();
+            assert!(progress.reach(1));
+            42
+        };
+        let watchdog = timeout_on_stall(&progress, work);
+        tokio::pin!(watchdog);
+
+        // Install the timer and leave replay waiting. Then make both branches
+        // ready without polling the watchdog in between.
+        assert!(futures::poll!(watchdog.as_mut()).is_pending());
+        tokio::time::advance(Duration::from_secs(31)).await;
+        release.send(()).unwrap();
+
+        assert_eq!(watchdog.await, Err(()));
+        assert_eq!(progress.snapshot().0, 0, "expired replay was polled");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replay_progress_cannot_renew_an_expired_deadline() {
+        let progress = ReplayProgress::new(Duration::from_secs(30));
+        tokio::time::advance(Duration::from_secs(31)).await;
+
+        assert!(!progress.reach(1));
+        assert_eq!(progress.snapshot().0, 0);
+        assert!(progress.stall_remaining().is_none());
     }
 
     #[tokio::test]
@@ -3438,7 +3474,7 @@ mod session_transition_tests {
         let replay_conn = Arc::clone(&conn);
         let supervisor = Arc::clone(&client);
         let replay = tokio::spawn(async move {
-            let progress = ReplayProgress::default();
+            let progress = ReplayProgress::new(REPLAY_STALL_TIMEOUT);
             supervisor
                 .replay_with_progress(&replay_conn, &progress, || {
                     NinePClient::has_external_owner(&supervisor)

--- a/zerofs/ninep-client/src/lib.rs
+++ b/zerofs/ninep-client/src/lib.rs
@@ -172,27 +172,57 @@ impl Drop for StatefulCancellationGuard<'_> {
 /// makes reconnect loop forever without ever installing a candidate.
 const REPLAY_STALL_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[derive(Default)]
+struct ReplayProgressState {
+    completed: u64,
+    total: u64,
+    last_advance: runtime::Clock,
+}
+
 struct ReplayProgress {
-    completed: AtomicU64,
-    total: AtomicU64,
+    state: Mutex<ReplayProgressState>,
+    advanced: Notify,
+}
+
+impl Default for ReplayProgress {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(ReplayProgressState {
+                completed: 0,
+                total: 0,
+                last_advance: runtime::Clock::now(),
+            }),
+            advanced: Notify::new(),
+        }
+    }
 }
 
 impl ReplayProgress {
     fn set_total(&self, total: usize) {
-        self.total.store(total as u64, Ordering::Relaxed);
+        self.state.lock().unwrap().total = total as u64;
     }
 
     fn reach(&self, completed: usize) {
-        self.completed
-            .fetch_max(completed as u64, Ordering::Relaxed);
+        let mut state = self.state.lock().unwrap();
+        let completed = completed as u64;
+        if completed <= state.completed {
+            return;
+        }
+        state.completed = completed;
+        state.last_advance = runtime::Clock::now();
+        drop(state);
+        self.advanced.notify_waiters();
     }
 
     fn snapshot(&self) -> (u64, u64) {
-        (
-            self.completed.load(Ordering::Relaxed),
-            self.total.load(Ordering::Relaxed),
-        )
+        let state = self.state.lock().unwrap();
+        (state.completed, state.total)
+    }
+
+    fn stall_remaining(&self, stall_timeout: Duration) -> Option<Duration> {
+        let elapsed = self.state.lock().unwrap().last_advance.elapsed();
+        stall_timeout
+            .checked_sub(elapsed)
+            .filter(|remaining| !remaining.is_zero())
     }
 }
 
@@ -202,26 +232,29 @@ impl ReplayProgress {
 /// it would reproduce the reconnect livelock this helper is meant to prevent.
 async fn timeout_on_stall<F>(
     stall_timeout: Duration,
-    progress: &AtomicU64,
+    progress: &ReplayProgress,
     future: F,
 ) -> Result<F::Output, ()>
 where
     F: std::future::Future,
 {
     let mut future = Box::pin(future);
-    let mut observed = progress.load(Ordering::Relaxed);
     loop {
-        let timer = Box::pin(runtime::sleep(stall_timeout));
-        match select(future, timer).await {
+        // Register before reading the deadline so an advance between the two
+        // cannot be lost. The timestamp still makes a delayed wake account for
+        // time elapsed since the event rather than since this task was polled.
+        let mut advanced = Box::pin(progress.advanced.notified());
+        advanced.as_mut().enable();
+        let Some(remaining) = progress.stall_remaining(stall_timeout) else {
+            return Err(());
+        };
+        let wake = Box::pin(async {
+            let timer = Box::pin(runtime::sleep(remaining));
+            let _ = select(advanced, timer).await;
+        });
+        match select(future, wake).await {
             Either::Left((output, _)) => return Ok(output),
-            Either::Right(((), pending)) => {
-                let current = progress.load(Ordering::Relaxed);
-                if current == observed {
-                    return Err(());
-                }
-                observed = current;
-                future = pending;
-            }
+            Either::Right(((), pending)) => future = pending,
         }
     }
 }
@@ -959,7 +992,7 @@ impl NinePClient {
         let progress = ReplayProgress::default();
         match timeout_on_stall(
             REPLAY_STALL_TIMEOUT,
-            &progress.completed,
+            &progress,
             self.replay_with_progress(&conn, &progress),
         )
         .await
@@ -3306,11 +3339,11 @@ mod session_transition_tests {
 
     #[tokio::test(start_paused = true)]
     async fn replay_watchdog_allows_total_work_longer_than_one_stall_window() {
-        let progress = AtomicU64::new(0);
+        let progress = ReplayProgress::default();
         let work = async {
             for completed in 1..=6 {
                 runtime::sleep(Duration::from_secs(17)).await;
-                progress.store(completed, Ordering::Relaxed);
+                progress.reach(completed);
             }
             42
         };
@@ -3323,7 +3356,8 @@ mod session_transition_tests {
 
     #[tokio::test(start_paused = true)]
     async fn replay_watchdog_rejects_a_candidate_that_stops_progressing() {
-        let progress = AtomicU64::new(7);
+        let progress = ReplayProgress::default();
+        progress.reach(7);
 
         assert!(
             timeout_on_stall(
@@ -3334,6 +3368,24 @@ mod session_transition_tests {
             .await
             .is_err()
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replay_watchdog_measures_from_the_last_progress_event() {
+        let progress = ReplayProgress::default();
+        let started = tokio::time::Instant::now();
+        let work = async {
+            runtime::sleep(Duration::from_secs(1)).await;
+            progress.reach(1);
+            std::future::pending::<()>().await;
+        };
+
+        assert!(
+            timeout_on_stall(Duration::from_secs(30), &progress, work)
+                .await
+                .is_err()
+        );
+        assert_eq!(started.elapsed(), Duration::from_secs(31));
     }
 
     #[test]

--- a/zerofs/ninep-client/src/lib.rs
+++ b/zerofs/ninep-client/src/lib.rs
@@ -29,6 +29,7 @@ use dashmap::mapref::entry::Entry;
 use dashmap::{DashMap, DashSet};
 use deku::prelude::*;
 use futures::StreamExt;
+use futures::future::{Either, select};
 use futures::stream::FuturesUnordered;
 pub use ninep_proto::NOFID;
 use ninep_proto::retry::MUTATION_RETRY_HORIZON;
@@ -163,8 +164,67 @@ impl Drop for StatefulCancellationGuard<'_> {
     }
 }
 
-/// Timeout for rebuilding one candidate session. Expiry discards the candidate.
-const REPLAY_TIMEOUT: Duration = Duration::from_secs(30);
+/// Longest replay interval allowed without completing a new state record.
+///
+/// This is deliberately a stall timeout rather than a deadline for the whole
+/// replay. Large mounts can have enough live fids that a healthy sequential
+/// replay takes longer than this; discarding that work on a fixed deadline
+/// makes reconnect loop forever without ever installing a candidate.
+const REPLAY_STALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Default)]
+struct ReplayProgress {
+    completed: AtomicU64,
+    total: AtomicU64,
+}
+
+impl ReplayProgress {
+    fn set_total(&self, total: usize) {
+        self.total.store(total as u64, Ordering::Relaxed);
+    }
+
+    fn reach(&self, completed: usize) {
+        self.completed
+            .fetch_max(completed as u64, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> (u64, u64) {
+        (
+            self.completed.load(Ordering::Relaxed),
+            self.total.load(Ordering::Relaxed),
+        )
+    }
+}
+
+/// Runs `future` while it continues to advance `progress`.
+///
+/// Keeping the original future across watchdog windows is important: restarting
+/// it would reproduce the reconnect livelock this helper is meant to prevent.
+async fn timeout_on_stall<F>(
+    stall_timeout: Duration,
+    progress: &AtomicU64,
+    future: F,
+) -> Result<F::Output, ()>
+where
+    F: std::future::Future,
+{
+    let mut future = Box::pin(future);
+    let mut observed = progress.load(Ordering::Relaxed);
+    loop {
+        let timer = Box::pin(runtime::sleep(stall_timeout));
+        match select(future, timer).await {
+            Either::Left((output, _)) => return Ok(output),
+            Either::Right(((), pending)) => {
+                let current = progress.load(Ordering::Relaxed);
+                if current == observed {
+                    return Err(());
+                }
+                observed = current;
+                future = pending;
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum ClientError {
@@ -896,7 +956,14 @@ impl NinePClient {
         // Settlement and snapshot/replay/install are mutually exclusive.
         let _transition = self.session_transition.lock().await;
         debug_assert_eq!(msize, self.msize);
-        match runtime::timeout(REPLAY_TIMEOUT, self.replay(&conn)).await {
+        let progress = ReplayProgress::default();
+        match timeout_on_stall(
+            REPLAY_STALL_TIMEOUT,
+            &progress.completed,
+            self.replay_with_progress(&conn, &progress),
+        )
+        .await
+        {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
                 self.discard_replay_candidate(&conn).await;
@@ -904,7 +971,11 @@ impl NinePClient {
             }
             Err(_) => {
                 self.discard_replay_candidate(&conn).await;
-                warn!("9P session replay stalled past {REPLAY_TIMEOUT:?}; retrying reconnect");
+                let (completed, total) = progress.snapshot();
+                warn!(
+                    "9P session replay made no progress for {REPLAY_STALL_TIMEOUT:?} \
+                     ({completed}/{total} records restored); retrying reconnect"
+                );
                 return Err(ClientError::Disconnected);
             }
         }
@@ -931,10 +1002,23 @@ impl NinePClient {
     }
 
     /// Rebuilds recorded fids and locks on `conn`. Roots precede descendants.
+    #[cfg(test)]
     async fn replay(&self, conn: &Conn) -> ClientResult<()> {
+        let progress = ReplayProgress::default();
+        self.replay_with_progress(conn, &progress).await
+    }
+
+    async fn replay_with_progress(
+        &self,
+        conn: &Conn,
+        progress: &ReplayProgress,
+    ) -> ClientResult<()> {
         let snapshot = self.state.lock().unwrap().clone();
+        let fid_count = snapshot.fids.len();
+        progress.set_total(fid_count.saturating_add(snapshot.locks.len()));
         let mut gone_unopened = Vec::new();
         let mut stale_opened = Vec::new();
+        let mut completed_fids = 0usize;
 
         let (roots, descendants): (Vec<_>, Vec<_>) = snapshot
             .fids
@@ -952,6 +1036,8 @@ impl NinePClient {
                 } else {
                     gone_unopened.push(fid);
                 }
+                completed_fids = completed_fids.saturating_add(1);
+                progress.reach(completed_fids);
                 continue;
             }
             if let Some(flags) = rec.opened {
@@ -976,13 +1062,16 @@ impl NinePClient {
                     Err(e) => return Err(e),
                 }
             }
+            completed_fids = completed_fids.saturating_add(1);
+            progress.reach(completed_fids);
         }
 
         let mut conflict_backoff = RECONNECT_BACKOFF_MIN;
+        let mut lock_high_water = 0usize;
         'lock_replay: loop {
             // Install the complete recorded lock set or roll back its prefix.
             let mut acquired = Vec::new();
-            for lk in &snapshot.locks {
+            for (lock_index, lk) in snapshot.locks.iter().enumerate() {
                 let body = Message::Tlock(Tlock {
                     fid: lk.fid,
                     lock_type: lk.lock_type,
@@ -995,6 +1084,11 @@ impl NinePClient {
                 match Self::send_raw_rpc(conn, body).await {
                     Ok(Message::Rlock(r)) if r.status == LockStatus::Success.as_wire() => {
                         acquired.push(lk);
+                        let completed_locks = lock_index.saturating_add(1);
+                        if completed_locks > lock_high_water {
+                            lock_high_water = completed_locks;
+                            progress.reach(fid_count.saturating_add(lock_high_water));
+                        }
                     }
                     Ok(Message::Rlock(Rlock {
                         status: LOCK_BLOCKED,
@@ -3208,6 +3302,38 @@ mod session_transition_tests {
             proc_id: 1,
             client_id: b"owner".to_vec(),
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replay_watchdog_allows_total_work_longer_than_one_stall_window() {
+        let progress = AtomicU64::new(0);
+        let work = async {
+            for completed in 1..=6 {
+                runtime::sleep(Duration::from_secs(17)).await;
+                progress.store(completed, Ordering::Relaxed);
+            }
+            42
+        };
+
+        assert_eq!(
+            timeout_on_stall(Duration::from_secs(30), &progress, work).await,
+            Ok(42)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replay_watchdog_rejects_a_candidate_that_stops_progressing() {
+        let progress = AtomicU64::new(7);
+
+        assert!(
+            timeout_on_stall(
+                Duration::from_secs(30),
+                &progress,
+                std::future::pending::<()>(),
+            )
+            .await
+            .is_err()
+        );
     }
 
     #[test]

--- a/zerofs/ninep-client/src/lib.rs
+++ b/zerofs/ninep-client/src/lib.rs
@@ -973,8 +973,21 @@ impl NinePClient {
         });
     }
 
+    /// Whether somebody other than the reconnect supervisor still owns us.
+    ///
+    /// The supervisor upgrades its weak reference before each attempt and is
+    /// therefore one strong owner itself. Once it is the only owner left,
+    /// continuing replay would postpone [`Self::drop`] and retain any locks
+    /// already installed on the candidate for no caller.
+    fn has_external_owner(supervisor: &Arc<Self>) -> bool {
+        Arc::strong_count(supervisor) > 1
+    }
+
     /// Dials, replays, and installs one replacement connection.
-    async fn reconnect_once(&self) -> ClientResult<()> {
+    async fn reconnect_once(self: &Arc<Self>) -> ClientResult<()> {
+        if !Self::has_external_owner(self) {
+            return Err(ClientError::Disconnected);
+        }
         let msize = self.msize();
         let (conn, msize) = Self::probe(
             &self.targets,
@@ -993,7 +1006,7 @@ impl NinePClient {
         match timeout_on_stall(
             REPLAY_STALL_TIMEOUT,
             &progress,
-            self.replay_with_progress(&conn, &progress),
+            self.replay_with_progress(&conn, &progress, || Self::has_external_owner(self)),
         )
         .await
         {
@@ -1038,15 +1051,21 @@ impl NinePClient {
     #[cfg(test)]
     async fn replay(&self, conn: &Conn) -> ClientResult<()> {
         let progress = ReplayProgress::default();
-        self.replay_with_progress(conn, &progress).await
+        self.replay_with_progress(conn, &progress, || true).await
     }
 
-    async fn replay_with_progress(
+    async fn replay_with_progress<C>(
         &self,
         conn: &Conn,
         progress: &ReplayProgress,
-    ) -> ClientResult<()> {
+        keep_replaying: C,
+    ) -> ClientResult<()>
+    where
+        C: Fn() -> bool,
+    {
+        ensure_replay_owned(&keep_replaying)?;
         let snapshot = self.state.lock().unwrap().clone();
+        ensure_replay_owned(&keep_replaying)?;
         let fid_count = snapshot.fids.len();
         progress.set_total(fid_count.saturating_add(snapshot.locks.len()));
         let mut gone_unopened = Vec::new();
@@ -1058,8 +1077,11 @@ impl NinePClient {
             .iter()
             .partition(|(_, rec)| rec.inode_id == rec.root_inode);
         for (&fid, rec) in roots.into_iter().chain(descendants) {
+            ensure_replay_owned(&keep_replaying)?;
             let has_lock = snapshot.locks.iter().any(|lock| lock.fid == fid);
-            let restored = self.replay_fid(conn, fid, rec).await?;
+            let restored = self.replay_fid(conn, fid, rec).await;
+            ensure_replay_owned(&keep_replaying)?;
+            let restored = restored?;
             if !restored {
                 if has_lock {
                     return Err(self.replay_state_lost("fid with a held lock could not be rebound"));
@@ -1095,6 +1117,7 @@ impl NinePClient {
                     Err(e) => return Err(e),
                 }
             }
+            ensure_replay_owned(&keep_replaying)?;
             completed_fids = completed_fids.saturating_add(1);
             progress.reach(completed_fids);
         }
@@ -1102,9 +1125,11 @@ impl NinePClient {
         let mut conflict_backoff = RECONNECT_BACKOFF_MIN;
         let mut lock_high_water = 0usize;
         'lock_replay: loop {
+            ensure_replay_owned(&keep_replaying)?;
             // Install the complete recorded lock set or roll back its prefix.
             let mut acquired = Vec::new();
             for (lock_index, lk) in snapshot.locks.iter().enumerate() {
+                ensure_replay_owned(&keep_replaying)?;
                 let body = Message::Tlock(Tlock {
                     fid: lk.fid,
                     lock_type: lk.lock_type,
@@ -1114,7 +1139,9 @@ impl NinePClient {
                     proc_id: lk.proc_id,
                     client_id: P9String::new(lk.client_id.clone()),
                 });
-                match Self::send_raw_rpc(conn, body).await {
+                let result = Self::send_raw_rpc(conn, body).await;
+                ensure_replay_owned(&keep_replaying)?;
+                match result {
                     Ok(Message::Rlock(r)) if r.status == LockStatus::Success.as_wire() => {
                         acquired.push(lk);
                         let completed_locks = lock_index.saturating_add(1);
@@ -1155,6 +1182,7 @@ impl NinePClient {
                     }
                 }
             }
+            ensure_replay_owned(&keep_replaying)?;
             if !gone_unopened.is_empty() || !stale_opened.is_empty() {
                 let mut state = self.state.lock().unwrap();
                 for fid in gone_unopened.iter().chain(&stale_opened) {
@@ -1168,6 +1196,7 @@ impl NinePClient {
                     self.stale_fids.insert(*fid);
                 }
             }
+            ensure_replay_owned(&keep_replaying)?;
             return Ok(());
         }
     }
@@ -2722,6 +2751,14 @@ impl NinePClient {
     }
 }
 
+fn ensure_replay_owned(keep_replaying: &impl Fn() -> bool) -> ClientResult<()> {
+    if keep_replaying() {
+        Ok(())
+    } else {
+        Err(ClientError::Disconnected)
+    }
+}
+
 impl Drop for NinePClient {
     fn drop(&mut self) {
         // Reader and writer tasks retain `Arc<Conn>` until explicit shutdown.
@@ -3386,6 +3423,50 @@ mod session_transition_tests {
                 .is_err()
         );
         assert_eq!(started.elapsed(), Duration::from_secs(31));
+    }
+
+    #[tokio::test]
+    async fn replay_stops_when_the_supervisor_is_the_last_owner() {
+        let (conn, mut requests) = test_conn_with_receiver();
+        let client = test_client(Arc::clone(&conn));
+        {
+            let mut state = client.state.lock().unwrap();
+            state.fids.insert(7, attach_fid(70, 0));
+            state.fids.insert(8, attach_fid(80, 0));
+        }
+
+        let replay_conn = Arc::clone(&conn);
+        let supervisor = Arc::clone(&client);
+        let replay = tokio::spawn(async move {
+            let progress = ReplayProgress::default();
+            supervisor
+                .replay_with_progress(&replay_conn, &progress, || {
+                    NinePClient::has_external_owner(&supervisor)
+                })
+                .await
+        });
+
+        let request = recv_request(&mut requests, "first replay record").await;
+        let Message::Trebind(rebind) = request.body else {
+            panic!("expected Trebind");
+        };
+        drop(client);
+        reply(
+            &conn,
+            request.tag,
+            Message::Rrebind(Rrebind {
+                qid: qid(rebind.inode_id),
+            }),
+        );
+
+        assert!(matches!(
+            replay.await.unwrap(),
+            Err(ClientError::Disconnected)
+        ));
+        assert!(
+            requests.try_recv().is_err(),
+            "replay must not start another record after its last caller drops"
+        );
     }
 
     #[test]

--- a/zerofs/ninep-client/src/runtime.rs
+++ b/zerofs/ninep-client/src/runtime.rs
@@ -2,16 +2,20 @@ use std::future::Future;
 use std::time::Duration;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) struct Clock(std::time::Instant);
+pub(crate) struct Clock(tokio::time::Instant);
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Clock {
     pub(crate) fn now() -> Self {
-        Self(std::time::Instant::now())
+        Self(tokio::time::Instant::now())
     }
 
     pub(crate) fn elapsed_millis(&self) -> u64 {
-        self.0.elapsed().as_millis() as u64
+        self.elapsed().as_millis() as u64
+    }
+
+    pub(crate) fn elapsed(&self) -> Duration {
+        self.0.elapsed()
     }
 }
 
@@ -38,7 +42,11 @@ impl Clock {
     }
 
     pub(crate) fn elapsed_millis(&self) -> u64 {
-        (monotonic_millis() - self.0).max(0.0) as u64
+        self.elapsed().as_millis() as u64
+    }
+
+    pub(crate) fn elapsed(&self) -> Duration {
+        Duration::from_millis((monotonic_millis() - self.0).max(0.0) as u64)
     }
 }
 

--- a/zerofs/ninep-client/src/runtime.rs
+++ b/zerofs/ninep-client/src/runtime.rs
@@ -15,7 +15,11 @@ impl Clock {
     }
 
     pub(crate) fn elapsed(&self) -> Duration {
-        self.0.elapsed()
+        Self::now().duration_since(self)
+    }
+
+    pub(crate) fn duration_since(&self, earlier: &Self) -> Duration {
+        self.0.saturating_duration_since(earlier.0)
     }
 }
 
@@ -46,7 +50,11 @@ impl Clock {
     }
 
     pub(crate) fn elapsed(&self) -> Duration {
-        Duration::from_millis((monotonic_millis() - self.0).max(0.0) as u64)
+        Self::now().duration_since(self)
+    }
+
+    pub(crate) fn duration_since(&self, earlier: &Self) -> Duration {
+        Duration::from_millis((self.0 - earlier.0).max(0.0) as u64)
     }
 }
 


### PR DESCRIPTION
Fixes #572 

## Summary

- Treat the 30-second replay limit as a **no-progress watchdog**, not a deadline for rebuilding the complete session.
- Apply the same behavior to both the async userspace 9P client and the native kernel client.
- Measure the watchdog from the actual last progress event, so sampling cannot extend the stall allowance.
- Give an expired userspace watchdog priority over simultaneously ready replay work, and refuse late progress renewal.
- Cancel replay and reset its candidate when the supervisor becomes the client's final owner.
- Reject kernel replay steps that finish after the existing stall deadline before renewing that deadline.
- Track a monotonic high-water mark during lock replay, so repeatedly acquiring and rolling back the same prefix does not count as forward progress.
- Add virtual-time regression coverage for long-but-progressing, precisely bounded, abandoned, and genuinely stalled replays.

## Problem

Session replay is sequential. The existing code wrapped the complete replay in one fixed 30-second timeout. A production mount with roughly 144,000 live fids was making healthy forward progress but could not rebuild the whole session within that deadline.

Every attempt therefore followed the same cycle:

1. Connect a healthy candidate.
2. Replay the same prefix of fids for 30 seconds.
3. Cancel and reset the candidate.
4. Back off and start again from the beginning.

The candidate was never installed, so requests behind the live gate remained blocked indefinitely. The native client had the equivalent whole-replay deadline and could hit the same failure mode on a sufficiently large session.

The initial progress watchdog also left four boundary cases:

1. It sampled a counter every watchdog window, which could grant another complete window even if progress occurred just after the preceding sample.
2. The supervisor's upgraded `Arc<NinePClient>` could keep a progressing replay alive after the final external owner disappeared.
3. The kernel path renewed a stall deadline after a successful replay step without first rejecting a step that completed after the old deadline.
4. The userspace selector polled replay before its timer, so delayed runtime polling could accept a late completion or let a late record renew an expired deadline.

## Implementation

### Userspace client

- `ReplayProgress` records each high-water event's monotonic timestamp along with the number of processed replay records and snapshot total.
- `timeout_on_stall` retains and continues polling the original replay future, but derives every wait from the actual last-progress timestamp and wakes immediately on progress.
- The watchdog branch is polled first, replay output is checked against the deadline before acceptance, and each high-water update refuses to replace an already-expired timestamp.
- Completing each fid advances progress.
- Lock replay advances progress only when it reaches a new high-water mark; reacquiring the same rolled-back prefix does not keep a permanently conflicted candidate alive.
- Replay checks external ownership before and after snapshotting and around every fid and lock record. When the supervisor is the only remaining owner, replay returns `Disconnected` and the existing candidate-reset path releases replayed server state before client destruction.
- A warning now reports processed versus total records when a candidate makes no progress for a full watchdog window.

### Native kernel client

- Rename the replay deadline to a replay stall deadline.
- Refresh it after each newly processed fid and each new lock high-water mark.
- Check the previous deadline immediately after every fid replay step and acquired lock step, before counting progress or refreshing the deadline.
- Preserve the existing deadline checks for candidate cleanup, lock rollback, and conflict backoff.
- Log whether fid or lock replay stopped advancing before returning `ETIMEDOUT`.

No wire protocol, storage format, or replay-state semantics change.

## Regression coverage

The new virtual-time tests prove that:

- replay work lasting 102 seconds succeeds with a 30-second watchdog when progress occurs every 17 seconds;
- a candidate that makes no progress is rejected after the watchdog window;
- progress at 1 second followed by a hang is rejected at 31 seconds, rather than receiving another complete sampling window;
- when the replay response and expired timer are both ready after delayed polling, the timer wins and replay is not polled;
- a progress update after expiry cannot renew the deadline;
- dropping the final external client owner while one of two fid records is in flight allows that record to finish, resets the candidate, and does not send the second record.

Repeated lock-conflict behavior remains covered by the existing replay tests.

## Validation

- `cargo test -p ninep-client` — 62 passed
- `cargo clippy -p ninep-client --all-targets -- -D warnings`
- `cargo check -p ninep-client`
- `cargo fmt --all -- --check`
- `make -C kernel test` — 18 protocol tests and 4 tag-space tests passed
- Native module built against Ubuntu `7.0.0-28-generic` with its exact Rust kernel metadata/toolchain
- Full v2.2.0 userspace binary built locally with the embedded Web UI
- Native-client smoke test against a v2.2.0 server: mount, metadata read, 4 KiB write, fsync, read/checksum, unlink, and clean unmount

The follow-up WebAssembly check could not be rerun because the distro Rust toolchain has no `wasm32-unknown-unknown` standard library installed and no `rustup`; the original watchdog change had passed this target before these follow-up commits.

## Branch

- `14748b8` — Prevent large session replay from livelocking
- `cab7d14` — Measure replay stalls from each progress event
- `cacd5d0` — Stop replay after the final caller drops
- `82b6044` — Reject replay progress after kernel stall expiry
- `4eb8598` — Prioritize expired replay watchdog deadlines
- Head: `xlab:fix/replay-progress-watchdog`
- Compare: https://github.com/Barre/ZeroFS/compare/main...xlab:fix/replay-progress-watchdog?expand=1