### PR TITLE
feat: support file-backed configuration secrets

### DIFF
--- a/documentation/src/app/configuration/page.mdx
+++ b/documentation/src/app/configuration/page.mdx
@@ -495,9 +495,11 @@ Substitution applies to these keys only; all other values are taken literally:
 
 For array values (`peers` and the `addresses` lists) each entry is expanded independently, so `peers = ["${PEER_A}", "${PEER_B}"]` substitutes each element on its own; a single variable is not split into multiple entries. Expansion runs on the whole string before an `addresses` entry is parsed as a socket address, so the host, the port, or the entire value may come from a variable: `addresses = ["${POD_IP}:2049"]` and `addresses = ["${BIND_ADDR}"]` are both valid.
 
-If a referenced variable is unset, the configuration fails to load with `Failed to expand environment variable`. A literal `$` in an expandable value (an encryption password, for example) must be written `$$`.
+If a referenced variable is unset, ZeroFS looks for the same name with a `_FILE` suffix. For example, `${ZEROFS_PASSWORD}` reads the UTF-8 contents of the file named by `ZEROFS_PASSWORD_FILE` when `ZEROFS_PASSWORD` is unset. A directly set variable always takes precedence over its `_FILE` fallback. Terminal LF and CRLF line endings are removed from file-backed values; other whitespace, including leading and trailing spaces, is preserved.
 
-This keeps secrets out of configuration files and lets the same file serve several environments.
+If neither `VAR` nor `VAR_FILE` is set, the configuration fails to load with `Failed to expand environment variable`. Missing or unreadable credential files and files that are not valid UTF-8 also fail configuration loading with the variable name and path in the error. A literal `$` in an expandable value (an encryption password, for example) must be written `$$`.
+
+This keeps secrets out of configuration files, supports file-based secret stores such as systemd credentials, and lets the same file serve several environments.
 
 ## System Integration
 
@@ -518,6 +520,13 @@ Restart=always
 RestartSec=5
 # Optional: Load environment variables for substitution
 EnvironmentFile=-/etc/zerofs/zerofs.env
+# Optional: Load encrypted file-backed credentials
+LoadCredentialEncrypted=zerofs-password:/etc/credstore.encrypted/zerofs-password
+LoadCredentialEncrypted=aws-access-key-id:/etc/credstore.encrypted/aws-access-key-id
+LoadCredentialEncrypted=aws-secret-access-key:/etc/credstore.encrypted/aws-secret-access-key
+Environment=ZEROFS_PASSWORD_FILE=%d/zerofs-password
+Environment=AWS_ACCESS_KEY_ID_FILE=%d/aws-access-key-id
+Environment=AWS_SECRET_ACCESS_KEY_FILE=%d/aws-secret-access-key
 
 [Install]
 WantedBy=multi-user.target
@@ -529,6 +538,17 @@ If using environment variable substitution, create `/etc/zerofs/zerofs.env`:
 ZEROFS_PASSWORD=your-secure-password
 AWS_ACCESS_KEY_ID=your-key
 AWS_SECRET_ACCESS_KEY=your-secret
+```
+
+The `LoadCredentialEncrypted` directives decrypt each credential into systemd's protected credentials directory. The matching `_FILE` variables point ZeroFS at those files through systemd's `%d` credentials-directory specifier. The configuration still references the unsuffixed names:
+
+```toml
+[storage]
+encryption_password = "${ZEROFS_PASSWORD}"
+
+[aws]
+access_key_id = "${AWS_ACCESS_KEY_ID}"
+secret_access_key = "${AWS_SECRET_ACCESS_KEY}"
 ```
 
 ### Docker
@@ -563,7 +583,7 @@ docker run -d \
   ghcr.io/barre/zerofs:latest run --config /config/zerofs.toml
 ```
 
-Configuration files can contain the encryption password and storage credentials. Restrict their file permissions and do not commit secrets to version control. Environment-variable substitution is available when the deployment's secret-management mechanism supplies values that way.
+Configuration files can contain the encryption password and storage credentials. Restrict their file permissions and do not commit secrets to version control. Environment-variable substitution accepts either direct values or `_FILE` paths when the deployment's secret-management mechanism supplies credentials that way.
 
 ## Logging Configuration
 

--- a/zerofs/src/config.rs
+++ b/zerofs/src/config.rs
@@ -1,4 +1,4 @@
-use crate::secrets::{CapturedPassword, EncryptionPassword};
+use crate::secrets::{CapturedPassword, EncryptionPassword, expand_environment};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::collections::HashSet;
@@ -765,13 +765,16 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    match shellexpand::env(&s) {
-        Ok(expanded) => Ok(expanded.into_owned()),
-        Err(e) => Err(serde::de::Error::custom(format!(
-            "Failed to expand environment variable: {}",
-            e
-        ))),
-    }
+    expand_config_value(&s)
+}
+
+fn expand_config_value<E>(value: &str) -> Result<String, E>
+where
+    E: de::Error,
+{
+    expand_environment(value).map_err(|error| {
+        de::Error::custom(format!("Failed to expand environment variable: {error}"))
+    })
 }
 
 fn deserialize_captured_encryption_password<'de, D>(
@@ -813,14 +816,7 @@ where
     D: Deserializer<'de>,
 {
     let opt = Option::<String>::deserialize(deserializer)?;
-    opt.map(|s| match shellexpand::env(&s) {
-        Ok(expanded) => Ok(expanded.into_owned()),
-        Err(e) => Err(serde::de::Error::custom(format!(
-            "Failed to expand environment variable: {}",
-            e
-        ))),
-    })
-    .transpose()
+    opt.map(|s| expand_config_value(&s)).transpose()
 }
 
 fn deserialize_expandable_string_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
@@ -828,16 +824,7 @@ where
     D: Deserializer<'de>,
 {
     let items = Vec::<String>::deserialize(deserializer)?;
-    items
-        .into_iter()
-        .map(|s| match shellexpand::env(&s) {
-            Ok(expanded) => Ok(expanded.into_owned()),
-            Err(e) => Err(serde::de::Error::custom(format!(
-                "Failed to expand environment variable: {}",
-                e
-            ))),
-        })
-        .collect()
+    items.into_iter().map(|s| expand_config_value(&s)).collect()
 }
 
 /// Expand `${VAR}` in each entry, then parse to a `SocketAddr`. Bind addresses
@@ -849,9 +836,7 @@ where
 {
     let mut set = HashSet::with_capacity(raw.len());
     for s in raw {
-        let expanded = shellexpand::env(&s).map_err(|e| {
-            de::Error::custom(format!("Failed to expand environment variable: {}", e))
-        })?;
+        let expanded = expand_config_value::<E>(&s)?;
         let addr = expanded.parse::<SocketAddr>().map_err(|e| {
             de::Error::custom(format!(
                 "invalid socket address {expanded:?} (expected host:port): {e}"
@@ -887,13 +872,7 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    match shellexpand::env(&s) {
-        Ok(expanded) => Ok(PathBuf::from(expanded.into_owned())),
-        Err(e) => Err(serde::de::Error::custom(format!(
-            "Failed to expand environment variable: {}",
-            e
-        ))),
-    }
+    expand_config_value(&s).map(PathBuf::from)
 }
 
 fn deserialize_optional_expandable_path<'de, D>(
@@ -903,14 +882,8 @@ where
     D: Deserializer<'de>,
 {
     let opt = Option::<String>::deserialize(deserializer)?;
-    opt.map(|s| match shellexpand::env(&s) {
-        Ok(expanded) => Ok(PathBuf::from(expanded.into_owned())),
-        Err(e) => Err(serde::de::Error::custom(format!(
-            "Failed to expand environment variable: {}",
-            e
-        ))),
-    })
-    .transpose()
+    opt.map(|s| expand_config_value(&s).map(PathBuf::from))
+        .transpose()
 }
 
 fn deserialize_expandable_hashmap<'de, D>(
@@ -921,13 +894,7 @@ where
 {
     let map = std::collections::HashMap::<String, String>::deserialize(deserializer)?;
     map.into_iter()
-        .map(|(k, v)| match shellexpand::env(&v) {
-            Ok(expanded) => Ok((k, expanded.into_owned())),
-            Err(e) => Err(serde::de::Error::custom(format!(
-                "Failed to expand environment variable: {}",
-                e
-            ))),
-        })
+        .map(|(key, value)| expand_config_value(&value).map(|value| (key, value)))
         .collect()
 }
 
@@ -955,8 +922,21 @@ impl Settings {
         let content = crate::secrets::read_file_locked(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
 
-        let mut settings: Settings = toml::from_str(content.expose_secret())
-            .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
+        let mut settings: Settings = toml::from_str(content.expose_secret()).map_err(|error| {
+            if error
+                .message()
+                .starts_with("Failed to expand environment variable")
+            {
+                anyhow::anyhow!(
+                    "Failed to parse config file: {}: {}",
+                    path.display(),
+                    error.message()
+                )
+            } else {
+                anyhow::Error::new(error)
+                    .context(format!("Failed to parse config file: {}", path.display()))
+            }
+        })?;
 
         let password = match settings
             .storage
@@ -1233,10 +1213,22 @@ impl Settings {
              #   access_key_id = \"${{AWS_ACCESS_KEY_ID}}\"\n\
              #   peers = [\"${{PEER_A_ADDR}}\", \"${{PEER_B_ADDR}}\"]\n\
              # \n\
+             # If VAR is unset and VAR_FILE is set, ZeroFS reads the UTF-8 value from\n\
+             # the file named by VAR_FILE. VAR takes precedence when both are set, and\n\
+             # terminal LF/CRLF line endings are removed from file-backed values.\n\
+             #\n\
+             # Expandable fields are storage url/encryption_password/storage_class; cache\n\
+             # dir; server unix_socket/addresses; prometheus addresses; all aws/azure/gcp\n\
+             # values; and replication node_id/replication_listen/peers.\n\
+             #\n\
+             # systemd credential example:\n\
+             #   LoadCredentialEncrypted=zerofs-password:/etc/credstore.encrypted/zerofs-password\n\
+             #   Environment=ZEROFS_PASSWORD_FILE=%d/zerofs-password\n\
+             #\n\
              # In array values (e.g. [replication] peers) each entry is expanded on\n\
              # its own; a single variable is not split into multiple entries.\n\
              #\n\
-             # All referenced environment variables must be set, or the config will fail to load.\n\
+             # Each reference needs VAR or VAR_FILE, or the config will fail to load.\n\
              #\n\
              # ============================================================================\n\
              # SERVER CONFIGURATION\n\
@@ -1311,6 +1303,194 @@ encryption_password = "${ZEROFS_TEST_PASSWORD}"
         let serialized = toml::to_string(&settings).unwrap();
         assert!(!serialized.contains("secret123"));
         assert!(!serialized.contains("encryption_password"));
+    }
+
+    #[test]
+    fn test_file_backed_config_secrets() {
+        let password_file = NamedTempFile::new().unwrap();
+        let access_key_file = NamedTempFile::new().unwrap();
+        let secret_key_file = NamedTempFile::new().unwrap();
+        std::fs::write(password_file.path(), "  file password  \r\n").unwrap();
+        std::fs::write(access_key_file.path(), "file-access-key\n").unwrap();
+        std::fs::write(secret_key_file.path(), "file secret\nkey\r\n").unwrap();
+
+        unsafe {
+            env::remove_var("ZEROFS_TEST_FILE_PASSWORD");
+            env::remove_var("ZEROFS_TEST_FILE_ACCESS_KEY");
+            env::remove_var("ZEROFS_TEST_FILE_SECRET_KEY");
+            env::set_var("ZEROFS_TEST_FILE_PASSWORD_FILE", password_file.path());
+            env::set_var("ZEROFS_TEST_FILE_ACCESS_KEY_FILE", access_key_file.path());
+            env::set_var("ZEROFS_TEST_FILE_SECRET_KEY_FILE", secret_key_file.path());
+        }
+
+        let config_content = r#"
+[cache]
+dir = "/tmp/cache"
+disk_size_gb = 1.0
+
+[storage]
+url = "s3://bucket/data"
+encryption_password = "${ZEROFS_TEST_FILE_PASSWORD}"
+
+[servers]
+
+[aws]
+access_key_id = "${ZEROFS_TEST_FILE_ACCESS_KEY}"
+secret_access_key = "${ZEROFS_TEST_FILE_SECRET_KEY}"
+"#;
+
+        let temp_file = NamedTempFile::new().unwrap();
+        std::fs::write(temp_file.path(), config_content).unwrap();
+        let (settings, password) = Settings::from_file(temp_file.path()).unwrap();
+
+        assert_eq!(password.expose_secret(), "  file password  ");
+        let aws = settings.aws.unwrap();
+        assert_eq!(aws.0.get("access_key_id").unwrap(), "file-access-key");
+        assert_eq!(aws.0.get("secret_access_key").unwrap(), "file secret\nkey");
+    }
+
+    #[test]
+    fn direct_environment_value_precedes_file_fallback() {
+        let password_file = NamedTempFile::new().unwrap();
+        let access_key_file = NamedTempFile::new().unwrap();
+        std::fs::write(password_file.path(), b"ignored-\xff").unwrap();
+        std::fs::write(access_key_file.path(), b"ignored-\xff").unwrap();
+
+        unsafe {
+            env::set_var("ZEROFS_TEST_PRECEDENCE_PASSWORD", "direct-password");
+            env::set_var("ZEROFS_TEST_PRECEDENCE_ACCESS_KEY", "direct-access-key");
+            env::set_var("ZEROFS_TEST_PRECEDENCE_PASSWORD_FILE", password_file.path());
+            env::set_var(
+                "ZEROFS_TEST_PRECEDENCE_ACCESS_KEY_FILE",
+                access_key_file.path(),
+            );
+        }
+
+        let config_content = r#"
+[cache]
+dir = "/tmp/cache"
+disk_size_gb = 1.0
+
+[storage]
+url = "s3://bucket/data"
+encryption_password = "$ZEROFS_TEST_PRECEDENCE_PASSWORD"
+
+[servers]
+
+[aws]
+access_key_id = "${ZEROFS_TEST_PRECEDENCE_ACCESS_KEY}"
+"#;
+
+        let temp_file = NamedTempFile::new().unwrap();
+        std::fs::write(temp_file.path(), config_content).unwrap();
+        let (settings, password) = Settings::from_file(temp_file.path()).unwrap();
+
+        assert_eq!(password.expose_secret(), "direct-password");
+        assert_eq!(
+            settings.aws.unwrap().0.get("access_key_id").unwrap(),
+            "direct-access-key"
+        );
+    }
+
+    #[test]
+    fn file_backed_variable_errors_are_contextual_and_redacted() {
+        let invalid_utf8 = NamedTempFile::new().unwrap();
+        std::fs::write(invalid_utf8.path(), b"must-not-appear-\xff").unwrap();
+        unsafe {
+            env::remove_var("ZEROFS_TEST_INVALID_FILE_SECRET");
+            env::set_var("ZEROFS_TEST_INVALID_FILE_SECRET_FILE", invalid_utf8.path());
+        }
+
+        let config_content = r#"
+[cache]
+dir = "/tmp/cache"
+disk_size_gb = 1.0
+
+[storage]
+url = "s3://bucket/must-not-appear-in-error"
+encryption_password = "test"
+
+[servers]
+
+[aws]
+secret_access_key = "${ZEROFS_TEST_INVALID_FILE_SECRET}"
+"#;
+        let temp_file = NamedTempFile::new().unwrap();
+        std::fs::write(temp_file.path(), config_content).unwrap();
+        let error = format!("{:#}", Settings::from_file(temp_file.path()).unwrap_err());
+
+        assert!(error.contains("ZEROFS_TEST_INVALID_FILE_SECRET_FILE"));
+        assert!(error.contains(&invalid_utf8.path().display().to_string()));
+        assert!(error.contains("UTF-8"));
+        assert!(
+            !error.contains("must-not-appear"),
+            "Error leaked secret/config: {error}"
+        );
+    }
+
+    #[test]
+    fn unreadable_file_backed_password_error_is_contextual_and_redacted() {
+        let unreadable = tempfile::tempdir().unwrap();
+        unsafe {
+            env::remove_var("ZEROFS_TEST_UNREADABLE_PASSWORD");
+            env::set_var("ZEROFS_TEST_UNREADABLE_PASSWORD_FILE", unreadable.path());
+        }
+
+        let config_content = r#"
+[cache]
+dir = "/tmp/cache"
+disk_size_gb = 1.0
+
+[storage]
+url = "s3://bucket/must-not-appear-in-error"
+encryption_password = "prefix-${ZEROFS_TEST_UNREADABLE_PASSWORD}"
+
+[servers]
+"#;
+        let temp_file = NamedTempFile::new().unwrap();
+        std::fs::write(temp_file.path(), config_content).unwrap();
+        let error = format!("{:#}", Settings::from_file(temp_file.path()).unwrap_err());
+
+        assert!(error.contains("ZEROFS_TEST_UNREADABLE_PASSWORD_FILE"));
+        assert!(error.contains(&unreadable.path().display().to_string()));
+        assert!(!error.contains("prefix-"), "Error leaked password: {error}");
+        assert!(
+            !error.contains("must-not-appear-in-error"),
+            "Error leaked config: {error}"
+        );
+    }
+
+    #[test]
+    fn missing_file_backed_password_error_is_contextual_and_redacted() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("missing-credential");
+        unsafe {
+            env::remove_var("ZEROFS_TEST_MISSING_FILE_PASSWORD");
+            env::set_var("ZEROFS_TEST_MISSING_FILE_PASSWORD_FILE", &missing);
+        }
+
+        let config_content = r#"
+[cache]
+dir = "/tmp/cache"
+disk_size_gb = 1.0
+
+[storage]
+url = "s3://bucket/must-not-appear-in-error"
+encryption_password = "prefix-${ZEROFS_TEST_MISSING_FILE_PASSWORD}"
+
+[servers]
+"#;
+        let temp_file = NamedTempFile::new().unwrap();
+        std::fs::write(temp_file.path(), config_content).unwrap();
+        let error = format!("{:#}", Settings::from_file(temp_file.path()).unwrap_err());
+
+        assert!(error.contains("ZEROFS_TEST_MISSING_FILE_PASSWORD_FILE"));
+        assert!(error.contains(&missing.display().to_string()));
+        assert!(!error.contains("prefix-"), "Error leaked password: {error}");
+        assert!(
+            !error.contains("must-not-appear-in-error"),
+            "Error leaked config: {error}"
+        );
     }
 
     #[test]
@@ -2066,6 +2246,8 @@ addresses = ["${ZEROFS_TEST_BAD_ADDR}"]
             env::set_var("AWS_SECRET_ACCESS_KEY", "secret");
         }
         let rendered = Settings::render_default_config().unwrap();
+        assert!(rendered.contains("If VAR is unset and VAR_FILE is set"));
+        assert!(rendered.contains("LoadCredentialEncrypted=zerofs-password"));
         let settings = write_and_load(&rendered).unwrap();
         assert!(
             settings

--- a/zerofs/src/secrets.rs
+++ b/zerofs/src/secrets.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, Result};
 use region::{Allocation, LockGuard, Protection};
 use std::fmt;
 use std::io::Read;
+use std::path::{Path, PathBuf};
 use zeroize::{Zeroize, Zeroizing};
 
 #[derive(Debug, thiserror::Error)]
@@ -170,7 +171,8 @@ impl EncryptionPassword {
     }
 
     /// Expand shell-style environment references, assembling the result
-    /// directly in locked memory.
+    /// directly in locked memory. An unset variable reads its `_FILE`
+    /// fallback directly into locked memory when configured.
     ///
     /// This preserves the syntax supported by the config's other expandable
     /// strings: `$VAR`, `${VAR}`, `${VAR:-default}`, and `$$` escaping.
@@ -180,6 +182,7 @@ impl EncryptionPassword {
         enum Piece<'a> {
             Literal(&'a str),
             Env(Zeroizing<String>),
+            File(LockedText),
         }
 
         let source = self.expose_secret();
@@ -216,10 +219,25 @@ impl EncryptionPassword {
                         _ => (expression, None),
                     };
 
-                    match std::env::var(name) {
-                        Ok(value) => pieces.push(Piece::Env(Zeroizing::new(value))),
-                        Err(_) if default.is_some() => {
+                    match environment_source(name) {
+                        Ok(Some(EnvironmentSource::Direct(value))) => {
+                            pieces.push(Piece::Env(Zeroizing::new(value)));
+                        }
+                        Ok(Some(EnvironmentSource::File {
+                            file_variable,
+                            path,
+                        })) => pieces.push(Piece::File(read_file_backed_locked(
+                            name,
+                            &file_variable,
+                            &path,
+                        )?)),
+                        Ok(None) if default.is_some() => {
                             pieces.push(Piece::Literal(default.expect("checked above")));
+                        }
+                        Ok(None) => {
+                            return Err(std::env::VarError::NotPresent).with_context(|| {
+                                format!("Failed to expand environment variable `{name}`")
+                            });
                         }
                         Err(error) => {
                             return Err(error).with_context(|| {
@@ -238,10 +256,24 @@ impl EncryptionPassword {
                         .last()
                         .expect("first character was checked");
                     let name = &after_dollar[..name_len];
-                    let value = std::env::var(name).with_context(|| {
-                        format!("Failed to expand environment variable `{name}`")
-                    })?;
-                    pieces.push(Piece::Env(Zeroizing::new(value)));
+                    match environment_source(name)
+                        .with_context(|| format!("Failed to expand environment variable `{name}`"))?
+                        .ok_or(std::env::VarError::NotPresent)
+                        .with_context(|| {
+                            format!("Failed to expand environment variable `{name}`")
+                        })? {
+                        EnvironmentSource::Direct(value) => {
+                            pieces.push(Piece::Env(Zeroizing::new(value)));
+                        }
+                        EnvironmentSource::File {
+                            file_variable,
+                            path,
+                        } => pieces.push(Piece::File(read_file_backed_locked(
+                            name,
+                            &file_variable,
+                            &path,
+                        )?)),
+                    }
                     remainder = &after_dollar[name_len..];
                 }
                 Some('$') => {
@@ -262,6 +294,7 @@ impl EncryptionPassword {
             .map(|piece| match piece {
                 Piece::Literal(text) => text.len(),
                 Piece::Env(value) => value.len(),
+                Piece::File(value) => value.expose_secret().len(),
             })
             .sum();
         let mut buf = LockedBuf::with_capacity(expanded_len)
@@ -270,6 +303,7 @@ impl EncryptionPassword {
             let bytes = match piece {
                 Piece::Literal(text) => text.as_bytes(),
                 Piece::Env(value) => value.as_bytes(),
+                Piece::File(value) => value.expose_secret().as_bytes(),
             };
             buf.push_bytes(bytes)
                 .context("Failed to protect encryption password in memory")?;
@@ -329,6 +363,13 @@ impl LockedText {
         Ok(Self(buf))
     }
 
+    fn trim_terminal_line_endings(mut self) -> Self {
+        while matches!(self.0.as_bytes().last(), Some(b'\n' | b'\r')) {
+            self.0.len -= 1;
+        }
+        self
+    }
+
     pub(crate) fn expose_secret(&self) -> &str {
         std::str::from_utf8(self.0.as_bytes()).expect("constructed from validated UTF-8")
     }
@@ -341,7 +382,7 @@ impl fmt::Debug for LockedText {
 }
 
 /// Read a file directly into locked memory.
-pub(crate) fn read_file_locked(path: &std::path::Path) -> Result<LockedText> {
+pub(crate) fn read_file_locked(path: &Path) -> Result<LockedText> {
     let mut file = std::fs::File::open(path)?;
     let size_hint = file.metadata().map(|m| m.len() as usize).unwrap_or(0);
     let mut buf = LockedBuf::with_capacity(size_hint.saturating_add(1))?;
@@ -354,6 +395,93 @@ pub(crate) fn read_file_locked(path: &std::path::Path) -> Result<LockedText> {
         }
     }
     LockedText::from_utf8(buf)
+}
+
+enum EnvironmentSource {
+    Direct(String),
+    File {
+        file_variable: String,
+        path: PathBuf,
+    },
+}
+
+fn environment_source(name: &str) -> Result<Option<EnvironmentSource>> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(EnvironmentSource::Direct(value))),
+        Err(error @ std::env::VarError::NotUnicode(_)) => {
+            Err(error).with_context(|| format!("Environment variable `{name}` is not valid UTF-8"))
+        }
+        Err(std::env::VarError::NotPresent) => {
+            let file_variable = format!("{name}_FILE");
+            match std::env::var(&file_variable) {
+                Ok(path) => Ok(Some(EnvironmentSource::File {
+                    file_variable,
+                    path: PathBuf::from(path),
+                })),
+                Err(std::env::VarError::NotPresent) => Ok(None),
+                Err(file_error) => Err(file_error).with_context(|| {
+                    format!("Environment variable `{file_variable}` is not valid UTF-8")
+                }),
+            }
+        }
+    }
+}
+
+fn read_file_backed_locked(name: &str, file_variable: &str, path: &Path) -> Result<LockedText> {
+    read_file_locked(path)
+        .with_context(|| {
+            format!(
+                "Failed to read `{file_variable}` for environment variable `{name}` from `{}`",
+                path.display()
+            )
+        })
+        .map(LockedText::trim_terminal_line_endings)
+}
+
+fn read_file_backed(name: &str, file_variable: &str, path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).with_context(|| {
+        format!(
+            "Failed to read `{file_variable}` for environment variable `{name}` from `{}`",
+            path.display()
+        )
+    })?;
+    let mut value = String::from_utf8(bytes).with_context(|| {
+        format!(
+            "`{file_variable}` for environment variable `{name}` at `{}` is not valid UTF-8",
+            path.display()
+        )
+    })?;
+    let trimmed_len = value
+        .trim_end_matches(|character| matches!(character, '\r' | '\n'))
+        .len();
+    value.truncate(trimmed_len);
+    Ok(value)
+}
+
+pub(crate) fn expand_environment(input: &str) -> Result<String> {
+    let mut deferred_error = None;
+    let expanded = shellexpand::env_with_context(input, |name| {
+        let value = match environment_source(name) {
+            Ok(Some(EnvironmentSource::Direct(value))) => Ok(Some(value)),
+            Ok(Some(EnvironmentSource::File {
+                file_variable,
+                path,
+            })) => read_file_backed(name, &file_variable, &path).map(Some),
+            Ok(None) => return Err(anyhow::anyhow!("environment variable not found")),
+            Err(error) => Err(error),
+        };
+        if let Err(error) = &value {
+            deferred_error.get_or_insert_with(|| format!("{error:#}"));
+        }
+        value
+    });
+
+    if let Some(error) = deferred_error {
+        return Err(anyhow::anyhow!(error));
+    }
+    expanded
+        .map(|expanded| expanded.into_owned())
+        .map_err(|error| anyhow::anyhow!("{error}"))
 }
 
 /// A fixed-size secret buffer stored in a pointer-stable locked allocation.
@@ -489,15 +617,22 @@ mod tests {
         );
     }
 
-    /// Differential parity with `shellexpand::env`, which still handles the
-    /// config's non-secret fields; the two implementations must not drift.
+    /// Differential parity with the ordinary config expansion path; the
+    /// locked parser and `shellexpand`-backed parser must not drift.
     #[test]
-    fn expansion_matches_shellexpand() {
+    fn password_expansion_matches_config_expansion() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let unreadable = tempfile::tempdir().unwrap();
+        std::fs::write(file.path(), "file-backed\r\n").unwrap();
         unsafe {
             std::env::set_var("ZEROFS_PARITY_SET", "value");
             std::env::set_var("ZEROFS_PARITY_EMPTY", "");
             std::env::set_var("ZEROFS_PARITY_µ", "mu");
             std::env::remove_var("ZEROFS_PARITY_UNSET");
+            std::env::remove_var("ZEROFS_PARITY_FILE_ONLY");
+            std::env::set_var("ZEROFS_PARITY_FILE_ONLY_FILE", file.path());
+            std::env::remove_var("ZEROFS_PARITY_BROKEN_FILE");
+            std::env::set_var("ZEROFS_PARITY_BROKEN_FILE_FILE", unreadable.path());
         }
 
         let corpus = [
@@ -509,6 +644,9 @@ mod tests {
             "$ZEROFS_PARITY_EMPTY",
             "${ZEROFS_PARITY_EMPTY:-default}",
             "${ZEROFS_PARITY_UNSET:-fallback}",
+            "${ZEROFS_PARITY_FILE_ONLY}",
+            "$ZEROFS_PARITY_FILE_ONLY",
+            "${ZEROFS_PARITY_BROKEN_FILE:-fallback}",
             "${ZEROFS_PARITY_UNSET:-}",
             "${ZEROFS_PARITY_UNSET:-$ZEROFS_PARITY_SET}",
             "$ZEROFS_PARITY_µ",
@@ -536,12 +674,12 @@ mod tests {
             let ours = EncryptionPassword::try_new(input)
                 .unwrap()
                 .expand_environment();
-            let theirs = shellexpand::env(input);
+            let theirs = expand_environment(input);
             match (&ours, &theirs) {
                 (Ok(ours), Ok(theirs)) => {
                     assert_eq!(
                         ours.expose_secret(),
-                        theirs.as_ref(),
+                        theirs.as_str(),
                         "diverged on {input:?}"
                     )
                 }
@@ -552,6 +690,26 @@ mod tests {
                 ),
             }
         }
+    }
+
+    #[test]
+    fn file_backed_password_rejects_invalid_utf8_without_leaking_contents() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), b"must-not-appear-\xff").unwrap();
+        unsafe {
+            std::env::remove_var("ZEROFS_INVALID_PASSWORD_FILE_TEST");
+            std::env::set_var("ZEROFS_INVALID_PASSWORD_FILE_TEST_FILE", file.path());
+        }
+
+        let error = EncryptionPassword::try_new("${ZEROFS_INVALID_PASSWORD_FILE_TEST}")
+            .unwrap()
+            .expand_environment()
+            .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("ZEROFS_INVALID_PASSWORD_FILE_TEST_FILE"));
+        assert!(error.contains(&file.path().display().to_string()));
+        assert!(error.contains("UTF-8"));
+        assert!(!error.contains("must-not-appear"));
     }
 
     #[test]


### PR DESCRIPTION
Extend the production environment-expansion policy so an explicitly set `NAME` keeps its current behavior, while an unset `NAME` falls back to reading the UTF-8 file named by `NAME_FILE`; if neither variable is available, retain the existing missing-variable failure. Apply that policy through every existing expandable-field deserializer in `zerofs/src/config.rs`, while updating the locked-memory expansion path in `zerofs/src/secrets.rs` so the encryption password is read and assembled without introducing an ordinary plaintext password copy. Treat the credential as a single textual value, removing terminal line endings as the issue's `cat` workaround does, and return contextual path/read/UTF-8 errors without including secret contents. ZeroFS configuration currently expands secret values only from process environment variables, while systemd credentials expose decrypted values as files beneath the credentials directory. Operators must therefore add a shell wrapper that reads each credential file and exports its contents before starting ZeroFS. The requested change should let the existing `$NAME` and `${NAME}` configuration references consume file-backed credentials without executing shell expressions or adding provider-specific configuration keys. The issue is open and unassigned, its thread contains no active claim, and the supplied timeline and competing-PR data show no prior or in-flight implementation. With only `ZEROFS_PASSWORD_FILE`, `AWS_ACCESS_KEY_ID_FILE`, and `AWS_SECRET_ACCESS_KEY_FILE` set to readable credential files, load a config that references the corresponding unsuffixed variables and verify the encryption password and AWS values contain the file contents rather than the paths; With both `NAME` and `NAME_FILE` set, verify the direct environment value wins so existing deployments do not change behavior; also verify ordinary expandable fields continue to support `$VAR`, `${VAR}`, defaults, and `$$` escaping.

Fixes #559
